### PR TITLE
Implement methods for amqp header exchange

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.40</nukleus.plugin.version>
 
-    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
+    <nukleus.amqp.spec.version>0.1</nukleus.amqp.spec.version>
     <reaktor.version>0.93</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <k3po.version>3.0.0-alpha-101</k3po.version>
     <k3po.nukleus.ext.version>0.45</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.36</nukleus.plugin.version>
+    <nukleus.plugin.version>0.40</nukleus.plugin.version>
 
     <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
     <reaktor.version>0.93</reaktor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <jmh.profilers.version>0.1.3</jmh.profilers.version>
 
     <k3po.version>3.0.0-alpha-101</k3po.version>
-    <k3po.nukleus.ext.version>0.42</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>0.45</k3po.nukleus.ext.version>
 
-    <nukleus.plugin.version>0.35</nukleus.plugin.version>
+    <nukleus.plugin.version>0.36</nukleus.plugin.version>
 
     <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
     <reaktor.version>0.93</reaktor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <artifactId>nukleus-maven-plugin</artifactId>
         <version>${nukleus.plugin.version}</version>
         <configuration>
-          <scopeNames>core amqp</scopeNames>
+          <scopeNames>core amqp protocol</scopeNames>
           <packageName>org.reaktivity.nukleus.amqp.internal.types</packageName>
         </configuration>
         <executions>
@@ -153,6 +153,9 @@
           <excludes>
             <exclude>src/conf/**</exclude>
           </excludes>
+          <mapping>
+            <idl>SLASHSTAR_STYLE</idl>
+          </mapping>
           <failIfUnknown>true</failIfUnknown>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,101 @@
     <checkstyle.suppressions.location>src/conf/checkstyle/suppressions.xml</checkstyle.suppressions.location>
     <jacoco.coverage.ratio>1.00</jacoco.coverage.ratio>
     <jacoco.missed.count>0</jacoco.missed.count>
+
+    <junit.version>4.12</junit.version>
+    <jmh.version>1.17.4</jmh.version>
+    <jmh.profilers.version>0.1.3</jmh.profilers.version>
+
+    <k3po.version>3.0.0-alpha-101</k3po.version>
+    <k3po.nukleus.ext.version>0.42</k3po.nukleus.ext.version>
+
+    <nukleus.plugin.version>0.35</nukleus.plugin.version>
+
+    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
+    <reaktor.version>0.93</reaktor.version>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.reaktivity</groupId>
+      <artifactId>nukleus-amqp.spec</artifactId>
+      <version>${nukleus.amqp.spec.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reaktivity</groupId>
+      <artifactId>reaktor</artifactId>
+      <version>${reaktor.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reaktivity</groupId>
+      <artifactId>reaktor</artifactId>
+      <type>test-jar</type>
+      <version>${reaktor.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kaazing</groupId>
+      <artifactId>k3po.junit</artifactId>
+      <version>${k3po.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kaazing</groupId>
+      <artifactId>k3po.lang</artifactId>
+      <version>${k3po.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.reaktivity</groupId>
+        <artifactId>nukleus-maven-plugin</artifactId>
+        <version>${nukleus.plugin.version}</version>
+        <configuration>
+          <scopeNames>core amqp</scopeNames>
+          <packageName>org.reaktivity.nukleus.amqp.internal.types</packageName>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
@@ -108,6 +199,9 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.2</version>
         <configuration>
+          <excludes>
+            <exclude>org/reaktivity/nukleus/amqp/internal/types/**/*.class</exclude>
+          </excludes>
           <rules>
             <rule>
               <element>BUNDLE</element>
@@ -144,12 +238,99 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.kaazing</groupId>
+        <artifactId>k3po-maven-plugin</artifactId>
+        <version>${k3po.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>start</goal>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.reaktivity</groupId>
+            <artifactId>k3po-nukleus-ext</artifactId>
+            <version>${k3po.nukleus.ext.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.22.1</version>
         <configuration>
           <argLine>@{argLine}</argLine>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.reaktivity.nukleus.amqp</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.gatling</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.4.2</version>
+        <configuration>
+          <shadeTestJar>true</shadeTestJar>
+          <outputFile>${project.build.directory}/${project.artifactId}-shaded.jar</outputFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                  <manifestEntries>
+                    <Class-Path>${project.artifactId}-shaded.jar</Class-Path>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+              <artifactSet>
+                <includes>
+                  <include>org.agrona:agrona</include>
+                  <include>org.reaktivity:nukleus</include>
+                  <include>org.reaktivity:reaktor</include>
+                  <include>org.openjdk.jmh:jmh-core</include>
+                  <include>net.sf.jopt-simple:jopt-simple</include>
+                  <include>org.apache.commons:commons-math3</include>
+                  <include>commons-cli:commons-cli</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpConfiguration.java
@@ -28,7 +28,7 @@ public class AmqpConfiguration extends Configuration
     static
     {
         final ConfigurationDef config = new ConfigurationDef("nukleus.amqp");
-        AMQP_CONTAINER_ID = config.property("container.id", "container-id:1");
+        AMQP_CONTAINER_ID = config.property("container.id");
         AMQP_CHANNEL_MAX = config.property("channel.max", 65535);
         AMQP_MAX_FRAME_SIZE = config.property("max.frame.size", 4294967295L);
         AMQP_CONFIG = config;

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpConfiguration.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import org.reaktivity.nukleus.Configuration;
+
+public class AmqpConfiguration extends Configuration
+{
+    public static final PropertyDef<String> AMQP_CONTAINER_ID;
+    public static final IntPropertyDef AMQP_CHANNEL_MAX;
+    public static final LongPropertyDef AMQP_MAX_FRAME_SIZE;
+
+    private static final ConfigurationDef AMQP_CONFIG;
+
+    static
+    {
+        final ConfigurationDef config = new ConfigurationDef("nukleus.amqp");
+        AMQP_CONTAINER_ID = config.property("container.id", "container-id:1");
+        AMQP_CHANNEL_MAX = config.property("channel.max", 65535);
+        AMQP_MAX_FRAME_SIZE = config.property("max.frame.size", 4294967295L);
+        AMQP_CONFIG = config;
+    }
+
+    public AmqpConfiguration(
+        Configuration config)
+    {
+        super(AMQP_CONFIG, config);
+    }
+
+    public String containerId()
+    {
+        return AMQP_CONTAINER_ID.get(this);
+    }
+
+    public int channelMax()
+    {
+        return AMQP_CHANNEL_MAX.getAsInt(this);
+    }
+
+    public long maxFrameSize()
+    {
+        return AMQP_MAX_FRAME_SIZE.getAsLong(this);
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpController.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpController.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.nativeOrder;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.Controller;
+import org.reaktivity.nukleus.ControllerSpi;
+
+import com.google.gson.Gson;
+
+public final class AmqpController implements Controller
+{
+    private static final int MAX_SEND_LENGTH = 1024;
+
+    private final ControllerSpi controllerSpi;
+    private final MutableDirectBuffer commandBuffer;
+    private final MutableDirectBuffer extensionBuffer;
+    private final Gson gson;
+
+    public AmqpController(
+        ControllerSpi controllerSpi)
+    {
+        this.controllerSpi = controllerSpi;
+        this.commandBuffer = new UnsafeBuffer(allocateDirect(MAX_SEND_LENGTH).order(nativeOrder()));
+        this.extensionBuffer = new UnsafeBuffer(allocateDirect(MAX_SEND_LENGTH).order(nativeOrder()));
+        this.gson = new Gson();
+    }
+
+    @Override
+    public int process()
+    {
+        return controllerSpi.doProcess();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        controllerSpi.doClose();
+    }
+
+    @Override
+    public Class<AmqpController> kind()
+    {
+        return AmqpController.class;
+    }
+
+    @Override
+    public String name()
+    {
+        return AmqpNukleus.NAME;
+    }
+
+    // TODO: add route methods
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpControllerFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpControllerFactorySpi.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import org.reaktivity.nukleus.Configuration;
+import org.reaktivity.nukleus.ControllerBuilder;
+import org.reaktivity.nukleus.ControllerFactorySpi;
+
+public final class AmqpControllerFactorySpi implements ControllerFactorySpi<AmqpController>
+{
+    @Override
+    public String name()
+    {
+        return AmqpNukleus.NAME;
+    }
+
+    @Override
+    public Class<AmqpController> kind()
+    {
+        return AmqpController.class;
+    }
+
+    @Override
+    public AmqpController create(
+        Configuration config,
+        ControllerBuilder<AmqpController> builder)
+    {
+        return builder.setFactory(AmqpController::new)
+                      .build();
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpElektron.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpElektron.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import static org.reaktivity.nukleus.route.RouteKind.SERVER;
+//import static org.reaktivity.nukleus.route.RouteKind.CLIENT;
+
+import org.reaktivity.nukleus.Elektron;
+import org.reaktivity.nukleus.route.RouteKind;
+//import org.reaktivity.nukleus.amqp.internal.stream.AmqpClientFactoryBuilder;
+import org.reaktivity.nukleus.amqp.internal.stream.AmqpServerFactoryBuilder;
+import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+final class AmqpElektron implements Elektron
+{
+    private final Map<RouteKind, StreamFactoryBuilder> streamFactoryBuilders;
+
+    AmqpElektron(
+        AmqpConfiguration config)
+    {
+        Map<RouteKind, StreamFactoryBuilder> streamFactoryBuilders = new EnumMap<>(RouteKind.class);
+        // TODO: streamFactoryBuilders.put(CLIENT, new AmqpClientFactoryBuilder(config));
+        streamFactoryBuilders.put(SERVER, new AmqpServerFactoryBuilder(config));
+        this.streamFactoryBuilders = streamFactoryBuilders;
+    }
+
+    @Override
+    public StreamFactoryBuilder streamFactoryBuilder(
+        RouteKind kind)
+    {
+        return streamFactoryBuilders.get(kind);
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s %s", getClass().getSimpleName(), streamFactoryBuilders);
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpNukleus.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpNukleus.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import org.reaktivity.nukleus.Nukleus;
+
+public final class AmqpNukleus implements Nukleus
+{
+    public static final String NAME = "amqp";
+
+    private final AmqpConfiguration config;
+
+    AmqpNukleus(
+        AmqpConfiguration config)
+    {
+        this.config = config;
+    }
+
+    @Override
+    public String name()
+    {
+        return AmqpNukleus.NAME;
+    }
+
+    @Override
+    public AmqpConfiguration config()
+    {
+        return config;
+    }
+
+    @Override
+    public AmqpElektron supplyElektron()
+    {
+        return new AmqpElektron(config);
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpNukleusFactorySpi.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/AmqpNukleusFactorySpi.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal;
+
+import org.reaktivity.nukleus.Configuration;
+import org.reaktivity.nukleus.NukleusFactorySpi;
+
+public final class AmqpNukleusFactorySpi implements NukleusFactorySpi
+{
+    @Override
+    public String name()
+    {
+        return AmqpNukleus.NAME;
+    }
+
+    @Override
+    public AmqpNukleus create(
+        Configuration config)
+    {
+        return new AmqpNukleus(new AmqpConfiguration(config));
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpClientFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpClientFactoryBuilder.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.stream;
+
+public class AmqpClientFactoryBuilder
+{
+
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
@@ -25,9 +25,16 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.reaktivity.nukleus.amqp.internal.types.codec.AmqpFrameFW;
-import org.reaktivity.nukleus.amqp.internal.types.codec.AmqpHeaderFW;
-import org.reaktivity.nukleus.amqp.internal.types.codec.AmqpOpenFrameFW;
-import org.reaktivity.nukleus.amqp.internal.types.stream.*;
+import org.reaktivity.nukleus.amqp.internal.types.codec.AmqpProtocolHeaderFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.AbortFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.AmqpBeginExFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.AmqpDataExFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.BeginFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.DataFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.EndFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.ResetFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.SignalFW;
+import org.reaktivity.nukleus.amqp.internal.types.stream.WindowFW;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.function.MessageConsumer;
 import org.reaktivity.nukleus.function.MessageFunction;
@@ -68,8 +75,7 @@ public final class AmqpServerFactory implements StreamFactory
 
     private final AmqpDataExFW amqpDataExRO = new AmqpDataExFW();
 
-    private final AmqpHeaderFW amqpHeaderRO = new AmqpHeaderFW();
-    private final AmqpHeaderFW.Builder amqpHeaderRW = new AmqpHeaderFW.Builder();
+    private final AmqpProtocolHeaderFW amqpProtocolHeaderRO = new AmqpProtocolHeaderFW();
     private final AmqpFrameFW amqpFrameRO = new AmqpFrameFW();
     private final AmqpFrameFW.Builder amqpFrameRW = new AmqpFrameFW.Builder();
 
@@ -263,7 +269,7 @@ public final class AmqpServerFactory implements StreamFactory
         }
 
         private void doAmqpOpen(
-            AmqpOpenFrameFW frame)
+            AmqpFrameFW frame)
         {
             // TODO
 //            final AmqpOpenFrameFW open = amqpOpenFrameRW.wrap(encodeBuffer, 0, encodeBuffer.capacity())
@@ -437,7 +443,7 @@ public final class AmqpServerFactory implements StreamFactory
         }
 
         private void onAmqpHeader(
-            AmqpHeaderFW header)
+            AmqpProtocolHeaderFW header)
         {
             if (header != null)
             {
@@ -454,17 +460,23 @@ public final class AmqpServerFactory implements StreamFactory
         }
 
         private boolean isAmqpHeaderValid(
-            AmqpHeaderFW header)
+            AmqpProtocolHeaderFW header)
         {
-            return header.protocolHeaderName().equals("AMQP")
-                && header.protocolId() == (byte)0x00
-                && header.protocolVersionMajor() == (byte)0x01
-                && header.protocolVersionMinor() == (byte)0x00
-                && header.protocolVersionRevision() == (byte)0x00;
+            String name = header.name().get((buffer, offset, limit) ->
+            {
+                byte[] nameInBytes = new byte[4];
+                buffer.getBytes(offset, nameInBytes, 0, 4);
+                return new String(nameInBytes);
+            });
+            return name.equals("AMQP")
+                && header.id() == (byte)0x00
+                && header.major() == (byte)0x01
+                && header.minor() == (byte)0x00
+                && header.revision() == (byte)0x00;
         }
 
         private void onAmqpOpen(
-            AmqpOpenFrameFW open)
+            AmqpFrameFW open)
         {
             // TODO
              doAmqpOpen(open);
@@ -526,12 +538,11 @@ public final class AmqpServerFactory implements StreamFactory
             final int offset,
             final int length)
         {
-            final AmqpHeaderFW amqpHeader = amqpHeaderRO.tryWrap(buffer, offset, offset + length);
-            onAmqpHeader(amqpHeader);
-            return amqpHeader == null ? 0 : amqpHeader.sizeof();
+            final AmqpProtocolHeaderFW protocolHeader = amqpProtocolHeaderRO.tryWrap(buffer, offset, offset + length);
+            onAmqpHeader(protocolHeader);
+            return protocolHeader == null ? 0 : protocolHeader.sizeof();
         }
 
-        // TODO
         private int decodeFrame(
             final DirectBuffer buffer,
             final int offset,
@@ -544,33 +555,31 @@ public final class AmqpServerFactory implements StreamFactory
             switch (amqpFrame.performative())
             {
                 case 0x00:
-                    // TODO: final AmqpOpenFrameFW amqpOpenFrame = amqpOpenFrameRO.wrap(buffer,
-                    // offset + FIELD_OFFSET_PAYLOAD, offset + length - FIELD_OFFSET_PAYLOAD);
-                    // onAmqpOpen(amqpOpenFrame);
+                    // TODO: onAmqpOpen()
                     break;
                 case 0x01:
-                    onAmqpBegin(amqpFrame);
+                    // TODO: onAmqpBegin();
                     break;
                 case 0x02:
-                    onAmqpAttach(amqpFrame);
+                    // TODO: onAmqpAttach();
                     break;
                 case 0x03:
-                    onAmqpFlow(amqpFrame);
+                    // TODO: onAmqpFlow();
                     break;
                 case 0x04:
-                    onAmqpTransfer(amqpFrame);
+                    // TODO: onAmqpTransfer();
                     break;
                 case 0x05:
-                    onAmqpDisposition(amqpFrame);
+                    // TODO: onAmqpDisposition();
                     break;
                 case 0x06:
-                    onAmqpDetach(amqpFrame);
+                    // TODO: onAmqpDetach();
                     break;
                 case 0x07:
-                    onAmqpEnd(amqpFrame);
+                    // TODO: onAmqpEnd();
                     break;
                 case 0x08:
-                    onAmqpClose(amqpFrame);
+                    // TODO: onAmqpClose();
                     break;
             }
             return 0; // TODO

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.stream;
+
+//import static java.nio.ByteOrder.BIG_ENDIAN;
+//import static java.nio.ByteOrder.nativeOrder;
+//import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+//import java.nio.ByteOrder;
+//import java.security.MessageDigest;
+//import java.util.Base64;
+//import java.util.Base64.Encoder;
+//import java.util.LinkedHashMap;
+//import java.util.Map;
+//import java.util.Objects;
+//import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import java.util.function.LongUnaryOperator;
+
+import org.agrona.DirectBuffer;
+//import org.agrona.LangUtil;
+import org.agrona.MutableDirectBuffer;
+//import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.reaktivity.nukleus.amqp.internal.types.stream.*;
+import org.reaktivity.nukleus.buffer.BufferPool;
+import org.reaktivity.nukleus.function.MessageConsumer;
+import org.reaktivity.nukleus.function.MessageFunction;
+import org.reaktivity.nukleus.function.MessagePredicate;
+import org.reaktivity.nukleus.route.RouteManager;
+import org.reaktivity.nukleus.stream.StreamFactory;
+import org.reaktivity.nukleus.amqp.internal.AmqpConfiguration;
+//import org.reaktivity.nukleus.amqp.internal.types.Flyweight;
+//import org.reaktivity.nukleus.amqp.internal.types.ListFW;
+import org.reaktivity.nukleus.amqp.internal.types.OctetsFW;
+import org.reaktivity.nukleus.amqp.internal.types.control.RouteFW;
+
+public final class AmqpServerFactory implements StreamFactory
+{
+    private final RouteFW routeRO = new RouteFW();
+
+    private final BeginFW beginRO = new BeginFW();
+    private final DataFW dataRO = new DataFW();
+    private final EndFW endRO = new EndFW();
+    private final AbortFW abortRO = new AbortFW();
+
+    private final BeginFW.Builder beginRW = new BeginFW.Builder();
+    private final DataFW.Builder dataRW = new DataFW.Builder();
+    private final EndFW.Builder endRW = new EndFW.Builder();
+    private final AbortFW.Builder abortRW = new AbortFW.Builder();
+
+    private final WindowFW windowRO = new WindowFW();
+    private final ResetFW resetRO = new ResetFW();
+    private final SignalFW signalRO = new SignalFW();
+
+    private final AmqpBeginExFW.Builder amqpBeginExRW = new AmqpBeginExFW.Builder();
+    private final AmqpDataExFW.Builder amqpDataExRW = new AmqpDataExFW.Builder();
+
+    private final WindowFW.Builder windowRW = new WindowFW.Builder();
+    private final ResetFW.Builder resetRW = new ResetFW.Builder();
+
+    private final OctetsFW payloadRO = new OctetsFW();
+
+    private final AmqpDataExFW amqpDataExRO = new AmqpDataExFW();
+
+    private final RouteManager router;
+    private final MutableDirectBuffer writeBuffer;
+    private final LongUnaryOperator supplyInitialId;
+    private final LongUnaryOperator supplyReplyId;
+    private final LongSupplier supplyTraceId;
+
+//    private final Long2ObjectHashMap<AmqpServerConnect> correlations;
+    private final MessageFunction<RouteFW> wrapRoute;
+
+    public AmqpServerFactory(
+        AmqpConfiguration config,
+        RouteManager router,
+        MutableDirectBuffer writeBuffer,
+        BufferPool bufferPool,
+        LongUnaryOperator supplyInitialId,
+        LongUnaryOperator supplyReplyId,
+        LongSupplier supplyTraceId)
+    {
+        this.router = requireNonNull(router);
+        this.writeBuffer = requireNonNull(writeBuffer);
+        this.supplyInitialId = requireNonNull(supplyInitialId);
+        this.supplyReplyId = requireNonNull(supplyReplyId);
+        this.supplyTraceId = requireNonNull(supplyTraceId);
+//        this.correlations = new Long2ObjectHashMap<>();
+        this.wrapRoute = this::wrapRoute;
+    }
+
+    @Override
+    public MessageConsumer newStream(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length,
+        MessageConsumer throttle)
+    {
+        final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+
+        final long acceptRouteId = begin.routeId();
+
+        final MessagePredicate filter = (t, b, o, l) -> true;
+        final RouteFW route = router.resolve(acceptRouteId, begin.authorization(), filter, this::wrapRoute);
+
+        MessageConsumer newStream = null;
+
+        if (route != null)
+        {
+            final long acceptInitialId = begin.streamId();
+            newStream = new AmqpServerConnection(
+                throttle,
+                acceptRouteId,
+                acceptInitialId)::onNetwork;
+
+        }
+
+        return newStream;
+    }
+
+    private RouteFW wrapRoute(
+        int msgTypeId,
+        DirectBuffer buffer,
+        int index,
+        int length)
+    {
+        return routeRO.wrap(buffer, index, index + length);
+    }
+
+    private final class AmqpServerConnection
+    {
+
+        private DecoderState decodeState;
+
+        private AmqpServerConnection(
+            MessageConsumer acceptReply,
+            long acceptRouteId,
+            long acceptId)
+        {
+
+            this.decodeState = this::decodeHeader;
+        }
+
+        private void onNetwork(
+            int msgTypeId,
+            DirectBuffer buffer,
+            int index,
+            int length)
+        {
+            switch (msgTypeId)
+            {
+                case BeginFW.TYPE_ID:
+                    final BeginFW begin = beginRO.wrap(buffer, index, index + length);
+                    onBegin(begin);
+                    break;
+                case DataFW.TYPE_ID:
+                    final DataFW data = dataRO.wrap(buffer, index, index + length);
+                    onData(data);
+                    break;
+                case EndFW.TYPE_ID:
+                    final EndFW end = endRO.wrap(buffer, index, index + length);
+                    onEnd(end);
+                    break;
+                case AbortFW.TYPE_ID:
+                    final AbortFW abort = abortRO.wrap(buffer, index, index + length);
+                    onAbort(abort);
+                    break;
+                case WindowFW.TYPE_ID:
+                    final WindowFW window = windowRO.wrap(buffer, index, index + length);
+                    onWindow(window);
+                    break;
+                case ResetFW.TYPE_ID:
+                    final ResetFW reset = resetRO.wrap(buffer, index, index + length);
+                    onReset(reset);
+                    break;
+                case SignalFW.TYPE_ID:
+                    final SignalFW signal = signalRO.wrap(buffer, index, index + length);
+                    onSignal(signal);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void onBegin(
+            BeginFW begin)
+        {
+            // TODO
+        }
+
+        private void onData(
+            DataFW data)
+        {
+            // TODO
+        }
+
+        private void onEnd(
+            EndFW end)
+        {
+            // TODO
+        }
+
+        private void onAbort(
+            AbortFW abort)
+        {
+            // TODO
+        }
+
+        private void onWindow(
+            WindowFW window)
+        {
+            // TODO
+        }
+
+        private void onReset(
+            ResetFW reset)
+        {
+            // TODO
+        }
+
+        private void onSignal(
+            SignalFW signal)
+        {
+            // TODO
+        }
+
+        private int decodeHeader(
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            return 0; // TODO
+        }
+    }
+
+    @FunctionalInterface
+    private interface DecoderState
+    {
+        int decode(DirectBuffer buffer, int offset, int length);
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
@@ -233,7 +233,7 @@ public final class AmqpServerFactory implements StreamFactory
                     .routeId(routeId)
                     .streamId(initialId)
                     .trace(traceId)
-                    .credit(initialCredit) // TODO
+                    .credit(initialCredit)
                     .padding(initialPadding)
                     .groupId(0)
                     .build();

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactoryBuilder.java
@@ -23,7 +23,6 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import org.agrona.MutableDirectBuffer;
-//import org.agrona.collections.Long2ObjectHashMap;
 import org.reaktivity.nukleus.amqp.internal.AmqpConfiguration;
 import org.reaktivity.nukleus.buffer.BufferPool;
 import org.reaktivity.nukleus.route.RouteManager;
@@ -33,7 +32,6 @@ import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
 public final class AmqpServerFactoryBuilder implements StreamFactoryBuilder
 {
     private final AmqpConfiguration config;
-//    private final Long2ObjectHashMap<Correlation<?>> correlations;
 
     private RouteManager router;
     private MutableDirectBuffer writeBuffer;
@@ -47,7 +45,6 @@ public final class AmqpServerFactoryBuilder implements StreamFactoryBuilder
         AmqpConfiguration config)
     {
         this.config = config;
-//        this.correlations = new Long2ObjectHashMap<>();
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactoryBuilder.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactoryBuilder.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.stream;
+
+import java.util.function.IntUnaryOperator;
+import java.util.function.LongFunction;
+import java.util.function.LongSupplier;
+import java.util.function.LongUnaryOperator;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+
+import org.agrona.MutableDirectBuffer;
+//import org.agrona.collections.Long2ObjectHashMap;
+import org.reaktivity.nukleus.amqp.internal.AmqpConfiguration;
+import org.reaktivity.nukleus.buffer.BufferPool;
+import org.reaktivity.nukleus.route.RouteManager;
+import org.reaktivity.nukleus.stream.StreamFactory;
+import org.reaktivity.nukleus.stream.StreamFactoryBuilder;
+
+public final class AmqpServerFactoryBuilder implements StreamFactoryBuilder
+{
+    private final AmqpConfiguration config;
+//    private final Long2ObjectHashMap<Correlation<?>> correlations;
+
+    private RouteManager router;
+    private MutableDirectBuffer writeBuffer;
+    private LongUnaryOperator supplyInitialId;
+    private LongUnaryOperator supplyReplyId;
+    private LongSupplier supplyTrace;
+    private ToIntFunction<String> supplyTypeId;
+    private Supplier<BufferPool> supplyBufferPool;
+
+    public AmqpServerFactoryBuilder(
+        AmqpConfiguration config)
+    {
+        this.config = config;
+//        this.correlations = new Long2ObjectHashMap<>();
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setRouteManager(
+        RouteManager router)
+    {
+        this.router = router;
+        return this;
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setWriteBuffer(
+        MutableDirectBuffer writeBuffer)
+    {
+        this.writeBuffer = writeBuffer;
+        return this;
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setInitialIdSupplier(
+        LongUnaryOperator supplyStreamId)
+    {
+        this.supplyInitialId = supplyStreamId;
+        return this;
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setReplyIdSupplier(
+        LongUnaryOperator supplyReplyId)
+    {
+        this.supplyReplyId = supplyReplyId;
+        return this;
+    }
+
+    @Override
+    public StreamFactoryBuilder setTraceSupplier(LongSupplier supplyTrace)
+    {
+        this.supplyTrace = supplyTrace;
+        return this;
+    }
+
+    @Override
+    public StreamFactoryBuilder setTypeIdSupplier(
+        ToIntFunction<String> supplyTypeId)
+    {
+        this.supplyTypeId = supplyTypeId;
+        return this;
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setGroupBudgetClaimer(
+        LongFunction<IntUnaryOperator> groupBudgetClaimer)
+    {
+        return this;
+    }
+
+    @Override
+    public AmqpServerFactoryBuilder setGroupBudgetReleaser(
+        LongFunction<IntUnaryOperator> groupBudgetReleaser)
+    {
+        return this;
+    }
+
+    @Override
+    public StreamFactoryBuilder setBufferPoolSupplier(
+        Supplier<BufferPool> supplyBufferPool)
+    {
+        this.supplyBufferPool = supplyBufferPool;
+        return this;
+    }
+
+    @Override
+    public StreamFactory build()
+    {
+        final BufferPool bufferPool = supplyBufferPool.get();
+
+        return new AmqpServerFactory(
+            config,
+            router,
+            writeBuffer,
+            bufferPool,
+            supplyInitialId,
+            supplyReplyId,
+            supplyTrace
+        );
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
@@ -28,21 +28,23 @@ public class AmqpFrameFW extends Flyweight
 
     private static final int FIELD_SIZE_LENGTH = BitUtil.SIZE_OF_INT;
 
-    private static final int FIELD_OFFSET_DOFF = FIELD_OFFSET_LENGTH + FIELD_SIZE_LENGTH;
+    public static final int FIELD_OFFSET_DOFF = FIELD_OFFSET_LENGTH + FIELD_SIZE_LENGTH;
 
     private static final int FIELD_SIZE_DOFF = BitUtil.SIZE_OF_BYTE;
 
-    private static final int FIELD_OFFSET_TYPE = FIELD_OFFSET_DOFF + FIELD_SIZE_DOFF;
+    public static final int FIELD_OFFSET_TYPE = FIELD_OFFSET_DOFF + FIELD_SIZE_DOFF;
 
     private static final int FIELD_SIZE_TYPE = BitUtil.SIZE_OF_BYTE;
 
-    private static final int FIELD_OFFSET_CHANNEL = FIELD_OFFSET_TYPE + FIELD_SIZE_TYPE;
+    public static final int FIELD_OFFSET_CHANNEL = FIELD_OFFSET_TYPE + FIELD_SIZE_TYPE;
 
     private static final int FIELD_SIZE_CHANNEL = BitUtil.SIZE_OF_SHORT;
 
-    private static final int FIELD_OFFSET_PERFORMATIVE = FIELD_OFFSET_CHANNEL + FIELD_SIZE_CHANNEL;
+    public static final int FIELD_OFFSET_PERFORMATIVE = FIELD_OFFSET_CHANNEL + FIELD_SIZE_CHANNEL;
 
     private static final int FIELD_SIZE_PERFORMATIVE = BitUtil.SIZE_OF_SHORT + BitUtil.SIZE_OF_BYTE;
+
+    public static final int FIELD_OFFSET_PAYLOAD = FIELD_OFFSET_PERFORMATIVE + FIELD_SIZE_PERFORMATIVE;
 
     public int performative()
     {
@@ -59,9 +61,7 @@ public class AmqpFrameFW extends Flyweight
     public AmqpFrameFW wrap(DirectBuffer buffer, int offset, int maxLimit)
     {
         super.wrap(buffer, offset, maxLimit);
-
         checkLimit(limit(), maxLimit);
-
         return this;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
@@ -21,7 +21,7 @@ import org.reaktivity.nukleus.amqp.internal.types.Flyweight;
 
 import org.agrona.BitUtil;
 
-// TODO: Complete this class
+// TODO: Replace with generated class and remove this class
 public class AmqpFrameFW extends Flyweight
 {
     public static final int FIELD_OFFSET_LENGTH = 0;

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpFrameFW.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.types.codec;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.nukleus.amqp.internal.types.Flyweight;
+
+import org.agrona.BitUtil;
+
+// TODO: Complete this class
+public class AmqpFrameFW extends Flyweight
+{
+    public static final int FIELD_OFFSET_LENGTH = 0;
+
+    private static final int FIELD_SIZE_LENGTH = BitUtil.SIZE_OF_INT;
+
+    private static final int FIELD_OFFSET_DOFF = FIELD_OFFSET_LENGTH + FIELD_SIZE_LENGTH;
+
+    private static final int FIELD_SIZE_DOFF = BitUtil.SIZE_OF_BYTE;
+
+    private static final int FIELD_OFFSET_TYPE = FIELD_OFFSET_DOFF + FIELD_SIZE_DOFF;
+
+    private static final int FIELD_SIZE_TYPE = BitUtil.SIZE_OF_BYTE;
+
+    private static final int FIELD_OFFSET_CHANNEL = FIELD_OFFSET_TYPE + FIELD_SIZE_TYPE;
+
+    private static final int FIELD_SIZE_CHANNEL = BitUtil.SIZE_OF_SHORT;
+
+    private static final int FIELD_OFFSET_PERFORMATIVE = FIELD_OFFSET_CHANNEL + FIELD_SIZE_CHANNEL;
+
+    private static final int FIELD_SIZE_PERFORMATIVE = BitUtil.SIZE_OF_SHORT + BitUtil.SIZE_OF_BYTE;
+
+    public int performative()
+    {
+        return buffer().getByte(offset() + FIELD_OFFSET_PERFORMATIVE + FIELD_SIZE_PERFORMATIVE) & 0x0f;
+    }
+
+    @Override
+    public int limit()
+    {
+        return 0;
+    }
+
+    @Override
+    public AmqpFrameFW wrap(DirectBuffer buffer, int offset, int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+
+        checkLimit(limit(), maxLimit);
+
+        return this;
+    }
+
+    public static final class Builder extends Flyweight.Builder<AmqpFrameFW>
+    {
+        public Builder()
+        {
+            super(new AmqpFrameFW());
+        }
+
+        @Override
+        public Builder wrap(MutableDirectBuffer buffer, int offset, int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+
+    private static void validateLength(
+        long length8bytes)
+    {
+        if (length8bytes >> 17L != 0L)
+        {
+            throw new IllegalStateException(String.format("frame payload=%d too long", length8bytes));
+        }
+    }
+
+    private static int lengthSize0(byte b)
+    {
+        switch (b & 0x7f)
+        {
+            case 0x7e:
+                return 3;
+
+            case 0x7f:
+                return 9;
+
+            default:
+                return 1;
+        }
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpHeaderFW.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpHeaderFW.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.types.codec;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.nukleus.amqp.internal.types.Flyweight;
+
+public class AmqpHeaderFW extends Flyweight
+{
+    public static final int FIELD_OFFSET_PROTOCOL_HEADER_NAME = 0;
+
+    private static final int FIELD_SIZE_PROTOCOL_HEADER_NAME = BitUtil.SIZE_OF_INT;
+
+    public static final int FIELD_OFFSET_PROTOCOL_ID = FIELD_OFFSET_PROTOCOL_HEADER_NAME + FIELD_SIZE_PROTOCOL_HEADER_NAME;
+
+    public static final int FIELD_SIZE_PROTOCOL_ID = BitUtil.SIZE_OF_BYTE;
+
+    public static final int FIELD_OFFSET_PROTOCOL_VERSION_MAJOR = FIELD_OFFSET_PROTOCOL_ID + FIELD_SIZE_PROTOCOL_ID;
+
+    public static final int FIELD_SIZE_PROTOCOL_VERSION_MAJOR = BitUtil.SIZE_OF_BYTE;
+
+    public static final int FIELD_OFFSET_PROTOCOL_VERSION_MINOR =
+        FIELD_OFFSET_PROTOCOL_VERSION_MAJOR + FIELD_SIZE_PROTOCOL_VERSION_MAJOR;
+
+    public static final int FIELD_SIZE_PROTOCOL_VERSION_MINOR = BitUtil.SIZE_OF_BYTE;
+
+    public static final int FIELD_OFFSET_PROTOCOL_VERSION_REVISION =
+        FIELD_OFFSET_PROTOCOL_VERSION_MINOR + FIELD_SIZE_PROTOCOL_VERSION_MINOR;
+
+    public static final int FIELD_SIZE_PROTOCOL_VERSION_REVISION = BitUtil.SIZE_OF_BYTE;
+
+    @Override
+    public int limit()
+    {
+        return maxLimit();
+    }
+
+    public String protocolHeaderName()
+    {
+        return buffer().getStringAscii(offset() + FIELD_OFFSET_PROTOCOL_HEADER_NAME);
+    }
+
+    public byte protocolId()
+    {
+        return buffer().getByte(offset() + FIELD_OFFSET_PROTOCOL_ID);
+    }
+
+    public byte protocolVersionMajor()
+    {
+        return buffer().getByte(offset() + FIELD_OFFSET_PROTOCOL_VERSION_MAJOR);
+    }
+
+    public byte protocolVersionMinor()
+    {
+        return buffer().getByte(offset() + FIELD_OFFSET_PROTOCOL_VERSION_MINOR);
+    }
+
+    public byte protocolVersionRevision()
+    {
+        return buffer().getByte(offset() + FIELD_OFFSET_PROTOCOL_VERSION_REVISION);
+    }
+
+    @Override
+    public AmqpHeaderFW wrap(DirectBuffer buffer, int offset, int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+
+        checkLimit(limit(), maxLimit);
+
+        return this;
+    }
+
+    public static final class Builder extends Flyweight.Builder<AmqpHeaderFW>
+    {
+        public Builder()
+        {
+            super(new AmqpHeaderFW());
+        }
+
+        @Override
+        public AmqpHeaderFW.Builder wrap(MutableDirectBuffer buffer, int offset, int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpHeaderFW.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/types/codec/AmqpHeaderFW.java
@@ -76,6 +76,14 @@ public class AmqpHeaderFW extends Flyweight
     }
 
     @Override
+    public AmqpHeaderFW tryWrap(DirectBuffer buffer, int offset, int maxLimit)
+    {
+        super.tryWrap(buffer, offset, maxLimit);
+
+        return this;
+    }
+
+    @Override
     public AmqpHeaderFW wrap(DirectBuffer buffer, int offset, int maxLimit)
     {
         super.wrap(buffer, offset, maxLimit);

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -175,8 +175,8 @@ scope protocol
             PROPERTIES (0x73L),
             APPLICATION_PROPERTIES (0x74L),
             DATA (0x75L),
-            AMQP_SEQUENCE (0x76L),
-            AMQP_VALUE (0x77L),
+            SEQUENCE (0x76L),
+            VALUE (0x77L),
             FOOTER (0x78L),
             RECEIVED (0x23L),
             ACCEPTED (0x24L),
@@ -320,8 +320,8 @@ scope protocol
 
         variant AmqpList switch (AmqpType) of list
         {
-            case LIST4: list[uint32, uint32];
-            case LIST1: list[uint8, uint8];
+            case LIST4: list[uint32, uint32, 0x40];
+            case LIST1: list[uint8, uint8, 0x40];
             case LIST0: list[0, 0];
         }
 
@@ -470,7 +470,7 @@ scope protocol
         typedef AmqpSymbol as AmqpIETFLanguageTag;
         typedef AmqpMap<AmqpSymbol, V> as AmqpFields<V>;
 
-        list ErrorList (AmqpList)
+        list AmqpErrorList (AmqpList)
         {
             required AmqpErrorType condition;
             AmqpString description;
@@ -479,7 +479,7 @@ scope protocol
 
         variant AmqpError switch (AmqpDescribedType+)
         {
-            case ERROR: ErrorList;
+            case ERROR: AmqpErrorList;
         }
 
         enum AmqpErrorType (AmqpSymbol)
@@ -497,18 +497,22 @@ scope protocol
             RESOURCE_DELETED ("amqp:resource-deleted"),
             ILLEGAL_STATE ("amqp:illegal-state"),
             FRAME_SIZE_TOO_SMALL ("amqp:frame-size-too-small"),
+
             CONNECTION_FORCED ("amqp:connection:forced"),
             CONNECTION_FRAMING_ERROR ("amqp:connection:framing-error"),
             CONNECTION_REDIRECT ("amqp:connection:redirect"),
+
             SESSION_WINDOW_VIOLATION ("amqp:session:window-violation"),
             SESSION_ERRANT_LINK ("amqp:session:errant-link"),
             SESSION_HANDLE_IN_USE ("amqp:session:handle-in-use"),
             SESSION_UNATTACHED_HANDLE ("amqp:session:unattached-handle"),
+
             LINK_DETACH_FORCED ("amqp:link:detach-forced"),
             LINK_TRANSFER_LIMIT_EXCEEDED ("amqp:link:transfer-limit-exceeded"),
             LINK_MESSAGE_SIZE_EXCEEDED ("amqp:link:message-size-exceeded"),
             LINK_REDIRECT ("amqp:link:redirect"),
             LINK_STOLEN ("amqp:link:stolen"),
+
             TRANSACTION_UNKNOWN_ID ("amqp:transaction:unknown-id"),
             TRANSACTION_ROLLBACK ("amqp:transaction:rollback"),
             TRANSACTION_TIMEOUT ("amqp:transaction:timeout")
@@ -523,8 +527,8 @@ scope protocol
             case PROPERTIES: AmqpProperties properties;
             case APPLICATION_PROPERTIES: AmqpMap applicationProperties;
             case DATA: AmqpBinary data;
-            case AMQP_SEQUENCE: AmqpList amqpSequence;
-            case AMQP_VALUE: AmqpValue amqpValue;
+            case SEQUENCE: AmqpList amqpSequence;
+            case VALUE: AmqpValue amqpValue;
             case FOOTER: AmqpMap footer;
         }
 

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -17,71 +17,77 @@ scope protocol
 {
     scope codec
     {
-        struct AmqpBinaryData
+        struct AmqpBinary8
         {
-            uint16 length;
+            uint8 length;
+            octets[length] bytes;
+        }
+
+        struct AmqpBinary32
+        {
+            uint32 length;
             octets[length] bytes;
         }
         
         union AmqpBoolean switch (uint8)
         {
-            case 0x56: uint8 boolean;
-            case 0x41: uint8 true; // true TODO: default value?
-            case 0x42: uint8 false; // false
+            case 0x56: uint8 booleanType;
+            case 0x41: uint8 trueType; // true TODO: default value?
+            case 0x42: uint8 falseType; // false
         }
 
         union AmqpUInt switch (uint8)
         {
-            case 0x70: uint32 uint;
-            case 0x52: uint8 smalluint;
-            case 0x43: uint8 uIntZero; // uint0 TODO: ideal behavior: case 0x43: ;
+            case 0x70: uint32 uIntType;
+            case 0x52: uint8 smallUIntType;
+            case 0x43: uint8 uIntZeroType; // uint0 TODO: ideal behavior: case 0x43: ;
         }
 
         union AmqpULong switch (uint8)
         {
-            case 0x80: uint64 ulong;
-            case 0x53: uint8 smallulong;
-            case 0x44: uint8 uLongZero; // ulong0 TODO: ideal behavior: case 0x44: ;
+            case 0x80: uint64 ulongType;
+            case 0x53: uint8 smallULongType;
+            case 0x44: uint8 uLongZeroType; // ulong0 TODO: ideal behavior: case 0x44: ;
         }
 
         union AmqpInt switch (uint8)
         {
-            case 0x71: int32 int;
-            case 0x54: int8 smallint;
+            case 0x71: int32 intType;
+            case 0x54: int8 smallIntType;
         }
 
         union AmqpLong switch (uint8)
         {
-            case 0x81: int64 long;
-            case 0x55: int8 smalllong;
+            case 0x81: int64 longType;
+            case 0x55: int8 smallLongType;
         }
 
         union AmqpBinary switch (uint8)
         {
-            case 0xa0: protocol::codec::AmqpBinaryData vbin8;
-            case 0xb0: protocol::codec::AmqpBinaryData vbin32;
+            case 0xa0: protocol::codec::AmqpBinary8 vbin8;
+            case 0xb0: protocol::codec::AmqpBinary32 vbin32;
         }
 
         union AmqpString switch (uint8)
         {
-            case 0xa1: protocol::codec::AmqpBinaryData str8;
-            case 0xb1: protocol::codec::AmqpBinaryData str32;
+            case 0xa1: string str8;
+            case 0xb1: string32 str32; // TODO: string32 not currently supported
         }
 
         union AmqpSymbol switch (uint8)
         {
-            case 0xa3: protocol::codec::AmqpBinaryData sym8;
-            case 0xb3: string sym32;
+            case 0xa3: string sym8;
+            case 0xb3: string32 sym32; // TODO: string32 not currently supported
         }
 
         union AmqpList switch (uint8)
         {
             case 0x45: int8 listZero; // list0 TODO: ideal behavior: case 0x45: ;
-            case 0xc0: protocol::codec::AmqpBinaryData list8;
-            case 0xd0: protocol::codec::AmqpBinaryData list32;
+            case 0xc0: // TODO: need to design
+            case 0xd0: // TODO: need to design
         }
 
-        union AmqpMap switch (uint8) // TODO: need to set the size of map
+        union AmqpMap switch (uint8) // TODO:
         {
             case 0xc1: list<protocol::codec::AmqpKeyValue> map8;
             case 0xd1: list<protocol::codec::AmqpKeyValue> map32;
@@ -126,7 +132,7 @@ scope protocol
             protocol::codec::AmqpMap info;
         }
 
-        enum AmqpError // TODO: need to store values associated with names
+        enum AmqpError // TODO: values are symbol - need to store values associated with names
         {
              INTERNAL_ERROR,
              NOT_FOUND,
@@ -147,8 +153,9 @@ scope protocol
         union AmqpDeliveryState switch (uint8)
         {
             case 0x23: protocol::codec::AmqpReceived received;
+            case 0x24: protocol::codec::AmqpList accepted; // TODO: should be empty list
             case 0x25: protocol::codec::AmqpRejected rejected;
-            case 0x26: protocol::codec::AmqpReleased released;
+            case 0x26: protocol::codec::AmqpList released; // TODO: should be empty list
             case 0x27: protocol::codec::AmqpModified modified;
             case 0x33: protocol::codec::AmqpDeclared declared;
             case 0x34: protocol::codec::AmqpTransactionalState transactionalState;
@@ -156,9 +163,9 @@ scope protocol
 
         union AmqpOutcome switch (uint8)
         {
-            case 0x24: protocol::codec::AmqpAccepted accepted;
+            case 0x24: protocol::codec::AmqpList accepted; // TODO: should be empty list
             case 0x25: protocol::codec::AmqpRejected rejected;
-            case 0x26: protocol::codec::AmqpReleased released;
+            case 0x26: protocol::codec::AmqpList released; // TODO: should be empty list
             case 0x27: protocol::codec::AmqpModified modified;
             case 0x33: protocol::codec::AmqpDeclared declared;
         }
@@ -169,19 +176,14 @@ scope protocol
             protocol::codec::AmqpULong sectionOffset; // required
         }
 
-        struct AmqpAccepted
-        {
-            // TODO
-        }
-
         struct AmqpRejected
         {
             protocol::codec::Error error;
         }
 
-        struct AmqpReleased
+        struct AmqpDeclared
         {
-            // TODO
+            protocol::codec::AmqpBinary txnId; // required
         }
 
         struct AmqpModified
@@ -198,12 +200,6 @@ scope protocol
         }
 
         // 3.5 Sources and Targets
-        enum AmqpDistributionMode
-        {
-            MOVE,
-            COPY
-        }
-
         struct AmqpSource
         {
             protocol::codec::AmqpString address;
@@ -212,7 +208,7 @@ scope protocol
             protocol::codec::AmqpUInt timeout;
             protocol::codec::AmqpBoolean dynamic;
             protocol::codec::AmqpMap dynamicNodeProperties;
-            protocol::codec::AmqpDistributionMode distributionMode;
+            protocol::codec::AmqpStandardDistributionMode distributionMode;
             protocol::codec::AmqpMap filter;
             protocol::codec::AmqpOutcome defaultOutcome;
             list<protocol::codec::AmqpSymbol> outcomes;
@@ -237,7 +233,7 @@ scope protocol
             UNSETTLED_STATE
         }
 
-        enum AmqpTerminusExpiryPolicy
+        enum AmqpTerminusExpiryPolicy // TODO: values are symbol
         {
             LINK_DETACH,
             SESSION_END,
@@ -245,7 +241,7 @@ scope protocol
             NEVER
         }
 
-        enum StandardDistributionMode
+        enum AmqpStandardDistributionMode // TODO: values are symbol
         {
             MOVE,
             COPY
@@ -263,7 +259,7 @@ scope protocol
             list<protocol::codec::AmqpSymbol> incomingLocales;
             list<protocol::codec::AmqpSymbol> offeredCapabilities;
             list<protocol::codec::AmqpSymbol> desiredCapabilities;
-            list<protocol::codec::AmqpProperty> properties;
+            list<protocol::codec::AmqpProperty> properties; // TODO: key is symbol and value can be any
         }
 
         struct AmqpBeginFrame

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -17,768 +17,777 @@ scope protocol
 {
     scope codec
     {
-        variant AmqpDescriptor switch (AmqpType+) as uint64
-        {
-            case DESCRIBED: AmqpULong;
-        }
-
-        struct AmqpFrame
-        {
-            uint32 size;
-            uint8 doff;
-            uint8 type;
-            uint16 channel;
-            AmqpPerformative performative;
-        }
-
-        union AmqpPerformative switch (AmqpDescribedType)
-        {
-            case OPEN: AmqpOpen open;
-            case BEGIN: AmqpBegin begin;
-            case ATTACH: AmqpAttach attach;
-            case FLOW: AmqpFlow flow;
-            case TRANSFER: AmqpTransfer transfer;
-            case DISPOSITION: AmqpDisposition disposition;
-            case DETACH: AmqpDetach detach;
-            case END: AmqpEnd end;
-            case CLOSE: AmqpClose close;
-        }
-
-        variant AmqpValue switch (AmqpType)
-        {
-            case DESCRIBED:
-                AmqpDescribedValue;
-            case NULL:
-                AmqpNull;
-            case BOOLEAN:
-            case TRUE:
-            case FALSE:
-                AmqpBoolean;
-            case UBYTE:
-                AmqpUByte;
-            case USHORT:
-                AmqpUShort;
-            case UINT4:
-            case UINT1:
-            case UINT0:
-                AmqpUInt;
-            case ULONG8:
-            case ULONG1:
-            case ULONG0:
-                AmqpULong;
-            case BYTE:
-                AmqpByte;
-            case SHORT:
-                AmqpShort;
-            case INT4:
-            case INT1:
-                AmqpInt;
-            case LONG8:
-            case LONG1:
-                AmqpLong;
-            case FLOAT:
-                AmqpFloat;
-            case DOUBLE:
-                AmqpDouble;
-            case DECIMAL32:
-                AmqpDecimal32;
-            case DECIMAL64:
-                AmqpDecimal64;
-            case DECIMAL128:
-                AmqpDecimal128;
-            case CHAR:
-                AmqpChar;
-            case TIMESTAMP:
-                AmqpTimestamp;
-            case UUID:
-                AmqpUUId;
-            case BINARY1:
-            case BINARY4:
-                AmqpBinary;
-            case STRING1:
-            case STRING4:
-                AmqpString;
-            case SYMBOL1:
-            case SYMBOL4:
-                AmqpSymbol;
-            case LIST0:
-            case LIST1:
-            case LIST4:
-                AmqpList;
-            case MAP1:
-            case MAP4:
-                AmqpMap;
-            case ARRAY1:
-            case ARRAY4:
-                AmqpArray;
-        }
-
-        enum AmqpType (uint8)
-        {
-            DESCRIBED (0x00),
-            NULL (0x40),
-            BOOLEAN (0x56),
-            TRUE (0x41),
-            FALSE (0x42),
-            UBYTE (0x50),
-            USHORT (0x60),
-            UINT4 (0x70),
-            UINT1 (0x52),
-            UINT0 (0x43),
-            ULONG8 (0x80),
-            ULONG1 (0x53),
-            ULONG0 (0x44),
-            BYTE (0x51),
-            SHORT (0x61),
-            INT4 (0x71),
-            INT1 (0x54),
-            LONG8 (0x81),
-            LONG1 (0x55),
-            FLOAT (0x72),
-            DOUBLE (0x82),
-            DECIMAL32 (0x74),
-            DECIMAL64 (0x84),
-            DECIMAL128 (0x94),
-            CHAR (0x73),
-            TIMESTAMP (0x83),
-            UUID (0x98),
-            BINARY1 (0xa0),
-            BINARY4 (0xb0),
-            STRING1 (0xa1),
-            STRING4 (0xb1),
-            SYMBOL1 (0xa3),
-            SYMBOL4 (0xb3),
-            LIST0 (0x45),
-            LIST1 (0xc0),
-            LIST4 (0xd0),
-            MAP1 (0xc1),
-            MAP4 (0xd1),
-            ARRAY1 (0xe0),
-            ARRAY4 (0xf0)
-        }
-
-        enum AmqpDescribedType (AmqpDescriptor)
-        {
-            OPEN (0x10L),
-            BEGIN (0x11L),
-            ATTACH (0x12L),
-            FLOW (0x13L),
-            TRANSFER (0x14L),
-            DISPOSITION (0x15L),
-            DETACH (0x16L),
-            END (0x17L),
-            CLOSE (0x18L),
-            ERROR (0x1dL),
-            HEADER (0x70L),
-            DELIVERY_ANNOTATIONS (0x71L),
-            MESSAGE_ANNOTATIONS (0x72L),
-            PROPERTIES (0x73L),
-            APPLICATION_PROPERTIES (0x74L),
-            DATA (0x75L),
-            SEQUENCE (0x76L),
-            VALUE (0x77L),
-            FOOTER (0x78L),
-            RECEIVED (0x23L),
-            ACCEPTED (0x24L),
-            REJECTED (0x25L),
-            RELEASED (0x26L),
-            MODIFIED (0x27L),
-            SOURCE (0x28L),
-            TARGET (0x29L),
-            DELETE_ON_CLOSE (0x2bL),
-            DELETE_ON_NO_LINKS (0x2cL),
-            DELETE_ON_NO_MESSAGES (0x2dL),
-            DELETE_ON_NO_LINKS_OR_MESSAGES (0x2eL),
-            COORDINATOR (0x30L),
-            DECLARE (0x31L),
-            DISCHARGE (0x32L),
-            DECLARED (0x33L),
-            TRANSACTIONAL_STATE (0x34L),
-            SASL_MECHANISMS (0x40L),
-            SASL_INIT (0x41L),
-            SASL_CHALLENGE (0x42L),
-            SASL_RESPONSE (0x43L),
-            SASL_OUTCOME (0x44L),
-        }
-
-        // 1.6 primitive type definitions
-        variant AmqpNull switch (AmqpType)
-        {
-            case NULL: 0;
-        }
-
-        variant AmqpBoolean switch (AmqpType) of uint8
-        {
-            case BOOLEAN: uint8;
-            case TRUE: 1;
-            case FALSE: 0;
-        }
-
-        variant AmqpUByte switch (AmqpType) of uint8
-        {
-            case UBYTE: uint8;
-        }
-
-        variant AmqpUShort switch (AmqpType) of uint16
-        {
-            case USHORT: uint16;
-        }
-
-        variant AmqpUInt switch (AmqpType) of uint32
-        {
-            case UINT4: uint32;
-            case UINT1: uint8;
-            case UINT0: 0;
-        }
-
-        variant AmqpULong switch (AmqpType) of uint64
-        {
-            case ULONG8: uint64;
-            case ULONG1: uint8;
-            case ULONG0: 0;
-        }
-
-        variant AmqpByte switch (AmqpType) of int8
-        {
-            case BYTE: int8;
-        }
-
-        variant AmqpShort switch (AmqpType) of int16
-        {
-            case SHORT: int16;
-        }
-
-        variant AmqpInt switch (AmqpType) of int32
-        {
-            case INT4: int32;
-            case INT1: int8;
-        }
-
-        variant AmqpLong switch (AmqpType) of int64
-        {
-            case LONG8: int64;
-            case LONG1: int8;
-        }
-
-        variant AmqpFloat switch (AmqpType)
-        {
-            case FLOAT: octets[4];
-        }
-
-        variant AmqpDouble switch (AmqpType)
-        {
-            case DOUBLE: octets[8];
-        }
-
-        variant AmqpDecimal32 switch (AmqpType)
-        {
-            case DECIMAL32: octets[4];
-        }
-
-        variant AmqpDecimal64 switch (AmqpType)
-        {
-            case DECIMAL64: octets[8];
-        }
-
-        variant AmqpDecimal128 switch (AmqpType)
-        {
-            case DECIMAL128: octets[16];
-        }
-
-        variant AmqpChar switch (AmqpType)
-        {
-            case CHAR: octets[4];
-        }
-
-        variant AmqpTimestamp switch (AmqpType)
-        {
-            case TIMESTAMP: int64;
-        }
-
-        variant AmqpUUId switch (AmqpType)
-        {
-            case UUID: string16;
-        }
-
-        variant AmqpBinary switch (AmqpType)
-        {
-            case BINARY1: octets[uint8];
-            case BINARY4: octets[uint32];
-        }
-
-        variant AmqpString switch (AmqpType) of string32
-        {
-            case STRING1: string;
-            case STRING4: string32;
-        }
-
-        variant AmqpSymbol switch (AmqpType) of string32
-        {
-            case SYMBOL1: string;
-            case SYMBOL4: string32;
-        }
-
-        variant AmqpList switch (AmqpType) of list
-        {
-            case LIST4: list[uint32, uint32, 0x40];
-            case LIST1: list[uint8, uint8, 0x40];
-            case LIST0: list[0, 0];
-        }
-
-        variant AmqpMap switch (AmqpType) of map
-        {
-            case MAP4: map[uint32];
-            case MAP1: map[uint8];
-        }
-
-        variant AmqpArray switch (AmqpType) of array
-        {
-            case ARRAY4: array[uint32, uint32];
-            case ARRAY1: array[uint8, uint8];
-        }
-
-        // 2.7 Performatives
-        list AmqpOpen (AmqpList)
-        {
-            required AmqpString containerId;
-            AmqpString hostname;
-            AmqpUInt maxFrameSize;
-            AmqpUShort channelMax;
-            AmqpMilliseconds idleTimeOut;
-            AmqpArray<AmqpIETFLanguageTag> outgoingLocales;
-            AmqpArray<AmqpIETFLanguageTag> incomingLocales;
-            AmqpArray<AmqpSymbol> offeredCapabilities;
-            AmqpArray<AmqpSymbol> desiredCapabilities;
-            AmqpFields<AmqpValue> properties;
-        }
-
-        list AmqpBegin (AmqpList)
-        {
-            AmqpUShort remoteChannel;
-            required AmqpTransferNumber nextOutgoingId;
-            required AmqpUInt incomingWindow;
-            required AmqpUInt outgoingWindow;
-            AmqpHandle handleMax;
-            AmqpArray<AmqpSymbol> offeredCapabilities;
-            AmqpArray<AmqpSymbol> desiredCapabilities;
-            AmqpFields<AmqpValue> properties;
-        }
-
-        list AmqpAttach (AmqpList)
-        {
-            required AmqpString name;
-            required AmqpHandle handle;
-            required AmqpRole role;
-            AmqpSenderSettleMode sndSettleMode;
-            AmqpReceiverSettleMode rcvSettleMode;
-            AmqpSource source;
-            AmqpTarget target;
-            AmqpMap unsettled;
-            AmqpBoolean incompleteUnsettled;
-            AmqpSequenceNo initialDeliveryCount;
-            AmqpULong maxMessageSize;
-            AmqpArray<AmqpSymbol> offeredCapabilities;
-            AmqpArray<AmqpSymbol> desiredCapabilities;
-            AmqpFields<AmqpValue> properties;
-        }
-
-        list AmqpFlow (AmqpList)
-        {
-            AmqpTransferNumber nextIncomingId;
-            required AmqpUInt incomingWindow;
-            required AmqpTransferNumber nextOutgoingId;
-            required AmqpUInt outgoingWindow;
-            AmqpHandle handle;
-            AmqpSequenceNo deliveryCount;
-            AmqpUInt linkCredit;
-            AmqpUInt available;
-            AmqpBoolean drain;
-            AmqpBoolean echo;
-            AmqpFields properties;
-        }
-
-        list AmqpTransfer (AmqpList)
-        {
-            required AmqpHandle handle;
-            AmqpDeliveryNumber deliveryId;
-            AmqpDeliveryTag deliveryTag;
-            AmqpMessageFormat messageFormat;
-            AmqpBoolean settled;
-            AmqpBoolean more;
-            AmqpReceiverSettleMode rcvSettleMode;
-            AmqpDeliveryState state;
-            AmqpBoolean resume;
-            AmqpBoolean aborted;
-            AmqpBoolean batchable;
-        }
-
-        list AmqpDisposition (AmqpList)
-        {
-            required AmqpRole role;
-            required AmqpDeliveryNumber first;
-            AmqpDeliveryNumber last;
-            AmqpBoolean settled;
-            AmqpDeliveryState state;
-            AmqpBoolean batchable;
-        }
-
-        list AmqpDetach (AmqpList)
-        {
-            required AmqpHandle handle;
-            AmqpBoolean closed;
-            Error error;
-        }
-
-        list AmqpEnd (AmqpList)
-        {
-            Error error;
-        }
-
-        list AmqpClose (AmqpList)
-        {
-            Error error;
-        }
-
-        // 2.8 Definitions
-        enum AmqpRole (AmqpBoolean)
-        {
-            SENDER (0),
-            RECEIVER (1)
-        }
-
-        enum AmqpSenderSettleMode (AmqpUByte)
-        {
-            UNSETTLED (0),
-            SETTLED (1),
-            MIZED (2)
-        }
-
-        enum AmqpReceiverSettleMode (AmqpUByte)
-        {
-            FIRST (0),
-            SECOND (1)
-        }
-
-        typedef AmqpUInt as AmqpHandle;
-        typedef AmqpUInt as AmqpSeconds;
-        typedef AmqpUInt as AmqpMilliseconds;
-        typedef AmqpBinary as AmqpDeliveryTag;
-        typedef AmqpSequenceNo as AmqpDeliveryNumber;
-        typedef AmqpSequenceNo as AmqpTransferNumber;
-        typedef AmqpUInt as AmqpSequenceNo;
-        typedef AmqpUInt as AmqpMessageFormat;
-        typedef AmqpSymbol as AmqpIETFLanguageTag;
-        typedef AmqpMap<AmqpSymbol, V> as AmqpFields<V>;
-
-        list AmqpErrorList (AmqpList)
-        {
-            required AmqpErrorType condition;
-            AmqpString description;
-            AmqpFields info;
-        }
-
-        variant AmqpError switch (AmqpDescribedType+)
-        {
-            case ERROR: AmqpErrorList;
-        }
-
-        enum AmqpErrorType (AmqpSymbol)
-        {
-            INTERNAL_ERROR ("amqp:internal-error"),
-            NOT_FOUND ("amqp:not-found"),
-            UNAUTHORIZED_ACCESS ("amqp:unauthorized-access"),
-            DECODE_ERROR ("amqp:decode-error"),
-            RESOURCE_LIMIT_EXCEEDED ("amqp:resource-limit-exceeded"),
-            NOT_ALLOWED ("amqp:not-allowed"),
-            INVALID_FIELD ("amqp:invalid-field"),
-            NOT_IMPLEMENTED ("amqp:not-implemented"),
-            RESOURCE_LOCKED ("amqp:resource-locked"),
-            PRECONDITION_FAILED ("amqp:precondition-failed"),
-            RESOURCE_DELETED ("amqp:resource-deleted"),
-            ILLEGAL_STATE ("amqp:illegal-state"),
-            FRAME_SIZE_TOO_SMALL ("amqp:frame-size-too-small"),
-
-            CONNECTION_FORCED ("amqp:connection:forced"),
-            CONNECTION_FRAMING_ERROR ("amqp:connection:framing-error"),
-            CONNECTION_REDIRECT ("amqp:connection:redirect"),
-
-            SESSION_WINDOW_VIOLATION ("amqp:session:window-violation"),
-            SESSION_ERRANT_LINK ("amqp:session:errant-link"),
-            SESSION_HANDLE_IN_USE ("amqp:session:handle-in-use"),
-            SESSION_UNATTACHED_HANDLE ("amqp:session:unattached-handle"),
-
-            LINK_DETACH_FORCED ("amqp:link:detach-forced"),
-            LINK_TRANSFER_LIMIT_EXCEEDED ("amqp:link:transfer-limit-exceeded"),
-            LINK_MESSAGE_SIZE_EXCEEDED ("amqp:link:message-size-exceeded"),
-            LINK_REDIRECT ("amqp:link:redirect"),
-            LINK_STOLEN ("amqp:link:stolen"),
-
-            TRANSACTION_UNKNOWN_ID ("amqp:transaction:unknown-id"),
-            TRANSACTION_ROLLBACK ("amqp:transaction:rollback"),
-            TRANSACTION_TIMEOUT ("amqp:transaction:timeout")
-        }
-
-        // 3.2 Message Format
-        union AmqpSection switch (AmqpDescribedType)
-        {
-            case HEADER: AmqpHeader header;
-            case DELIVERY_ANNOTATIONS: AmqpMap deliveryAnnotations;
-            case MESSAGE_ANNOTATIONS: AmqpMap messageAnnotations;
-            case PROPERTIES: AmqpProperties properties;
-            case APPLICATION_PROPERTIES: AmqpMap applicationProperties;
-            case DATA: AmqpBinary data;
-            case SEQUENCE: AmqpList amqpSequence;
-            case VALUE: AmqpValue amqpValue;
-            case FOOTER: AmqpMap footer;
-        }
-
-        list AmqpHeader (AmqpList)
-        {
-            AmqpBoolean durable;
-            AmqpUByte priority;
-            AmqpMilliseconds ttl;
-            AmqpBoolean firstAcquirer;
-            AmqpUInt deliveryCount;
-        }
-
-        list AmqpProperties (AmqpList)
-        {
-            AmqpMessageId messageId;
-            AmqpBinary userId;
-            AmqpAddress to;
-            AmqpString subject;
-            AmqpAddress replyTo;
-            AmqpMessageId correlationId;
-            AmqpSymbol contentType;
-            AmqpSymbol contentEncoding;
-            AmqpTimestamp absoluteExpiryTime;
-            AmqpTimestamp creationTime;
-            AmqpString groupId;
-            AmqpSequenceNo group-sequence;
-            AmqpString replyToGroupId;
-        }
-
-        variant AmqpMessageId switch (AmqpType)
-        {
-            case ULONG8:
-            case ULONG1:
-            case ULONG0:
-                AmqpULong;
-            case UUID:
-                AmqpUUId;
-            case BINARY1:
-            case BINARY4:
-                AmqpBinary;
-            case STRING1:
-            case STRING4:
-                AmqpString;
-        }
-
-        typedef AmqpString as AmqpAddress;
-
-        // 3.4 Delivery state
-        union AmqpDeliveryState switch (AmqpDescribedType)
-        {
-            case RECEIVED: AmqpReceived received;
-            case ACCEPTED: AmqpList accepted;
-            case REJECTED: AmqpRejected rejected;
-            case RELEASED: AmqpReleased AmqpList;
-            case MODIFIED: AmqpModified modified;
-            case DECLARED: AmqpDeclared declared;
-            case TRANSACTIONAL_STATE: AmqpTransactionalState transactionalState;
-        }
-
-        union AmqpOutcome switch (AmqpDescribedType)
-        {
-            case ACCEPTED: AmqpList accepted;
-            case REJECTED: AmqpRejected rejected;
-            case RELEASED: AmqpReleased AmqpList;
-            case MODIFIED: AmqpModified modified;
-            case DECLARED: AmqpDeclared declared;
-        }
-
-        list AmqpReceived (AmqpList)
-        {
-            required AmqpUInt sectionNumber;
-            required AmqpULong sectionOffset;
-        }
-
-        list AmqpRejected (AmqpList)
-        {
-            Error error;
-        }
-
-        list AmqpModified (AmqpList)
-        {
-            AmqpBoolean deliveryFailed;
-            AmqpBoolean undeliverableHere;
-            AmqpFields<AmqpValue> messageAnnotations;
-        }
-
-        // 3.5 Sources and Targets
-        list AmqpSourceList (AmqpList)
-        {
-            AmqpAddress address;
-            AmqpTerminusDurability durable;
-            AmqpTerminusExpiryPolicy expiryPolicy;
-            AmqpSeconds timeout;
-            AmqpBoolean dynamic;
-            AmqpNodeProperties dynamicNodeProperties;
-            AmqpStandardDistributionMode distributionMode;
-            AmqpFilterSet filter;
-            AmqpOutcome defaultOutcome;
-            AmqpArray<AmqpSymbol> outcomes;
-            AmqpArray<AmqpSymbol> capabilities;
-        }
-
-        variant AmqpSource switch (AmqpDescribedType+)
-        {
-            case SOURCE: AmqpSourceList;
-        }
-
-        union AmqpTarget switch (AmqpDescribedType)
-        {
-            case TARGET: AmqpTargetList targetList;
-            case COORDINATOR: AmqpCoordinator coordinatorList;
-        }
-
-        list AmqpTargetList (AmqpList)
-        {
-            AmqpAddress address;
-            AmqpTerminusDurability durable;
-            AmqpTerminusExpiryPolicy expiryPolicy;
-            AmqpSeconds timeout;
-            AmqpBoolean dynamic;
-            AmqpNodeProperties dynamicNodeProperties;
-            AmqpArray<AmqpSymbol> capabilities;
-        }
-
-        enum AmqpTerminusDurability (uint8)
-        {
-            NONE (0),
-            CONFIGURATION (1),
-            UNSETTLED_STATE (2)
-        }
-
-        enum AmqpTerminusExpiryPolicy (AmqpSymbol)
-        {
-            LINK_DETACH ("link-detach"),
-            SESSION_END ("session-end"),
-            CONNECTION_CLOSE ("connection-close"),
-            NEVER ("never")
-        }
-
-        enum AmqpStandardDistributionMode (AmqpSymbol)
-        {
-            MOVE ("move"),
-            COPY ("copy")
-        }
-
-        typedef AmqpMap as AmqpFilterSet;
-        typedef AmqpFields as AmqpNodeProperties;
-
-        union AmqpLifetimePolicy switch (AmqpDescribedType)
-        {
-            case DELETE_ON_CLOSE: AmqpList deleteOnClose;
-            case DELETE_ON_NO_LINKS: AmqpList deleteOnNoLinks;
-            case DELETE_ON_NO_MESSAGES: AmqpList deleteOnNoMessages;
-            case DELETE_ON_NO_LINKS_OR_MESSAGES: AmqpList deleteOnNoLinksOrMessages;
-        }
-
-        // 4.5 Coordination
-        list AmqpCoordinator (AmqpList)
-        {
-            AmqpArray<AmqpTransactionCapability> capabilities;
-        }
-
-        list AmqpDeclareList (AmqpList)
-        {
-            AmqpTxnId globalId;
-        }
-
-        variant AmqpDeclare switch (AmqpDescribedType+)
-        {
-            case DECLARE: AmqpDeclareList;
-        }
-
-        list AmqpDischargeList (AmqpList)
-        {
-            required AmqpTxnId txnId;
-            AmqpBoolean fail;
-        }
-
-        variant AmqpDischarge switch (AmqpDescribedType+)
-        {
-            case DISCHARGE: AmqpDischargeList;
-        }
-
-        typedef AmqpBinary as AmqpTxnId;
-
-        list AmqpDeclared (AmqpList)
-        {
-            required AmqpTxnId txnId;
-        }
-
-        list AmqpTransactionalState (AmqpList)
-        {
-            required AmqpBinary txnId;
-            AmqpOutcome outcome;
-        }
-
-        enum AmqpTransactionCapability (AmqpSymbol)
-        {
-            LOCAL_TRANSACTIONS ("amqp:local-transactions"),
-            DISTRIBUTED_TRANSACTIONS ("amqp:distributed-transactions"),
-            PROMOTABLE_TRANSACTIONS ("amqp:promotable-transactions"),
-            MULTI_TXNS_PER_SSN ("amqp:multi-txns-per-ssn"),
-            MULTI_SSNS_PER_TXN ("amqp:multi-ssns-per-txn")
-        }
-
-        // 5.3 Security Frame Bodies
-        union AmqpSaslFrame switch (AmqpDescribedType)
-        {
-            case SASL_MECHANISMS: AmqpSaslMechanisms saslMechanisms;
-            case SASL_INIT: AmqpSaslInit saslInit;
-            case SASL_CHALLENGE: AmqpSaslChallenge saslChallenge;
-            case SASL_RESPONSE: AmqpSaslResponse saslResponse;
-            case SASL_OUTCOME: AmqpSaslOutcome saslOutcome;
-        }
-
-        list AmqpSaslMechanisms (AmqpList)
-        {
-            required AmqpArray<AmqpSymbol> saslServerMechanisms;
-        }
-
-        list AmqpSaslInit (AmqpList)
-        {
-            required AmqpSymbol mechanism;
-            AmqpBinary initialResponse;
-            AmqpString hostname;
-        }
-
-        list AmqpSaslChallenge (AmqpList)
-        {
-            required AmqpBinary challenge;
-        }
-
-        list AmqpSaslResponse (AmqpList)
-        {
-            required AmqpBinary response;
-        }
-
-        list AmqpSaslOutcome (AmqpList)
-        {
-            required AmqpSaslCode code;
-            AmqpBinary additionalData;
-        }
-
-        enum AmqpSaslCode (AmqpUByte)
-        {
-            OK (0),
-            AUTH (1),
-            SYS (2),
-            SYS_PERM (3),
-            SYS_TEMP (4)
-        }
+//        variant AmqpDescriptor switch (AmqpType+) of uint64
+//        {
+//            case DESCRIBED: AmqpULong;
+//        }
+
+        struct AmqpProtocolHeader
+        {
+            octets[4] name;
+            uint8 id = 0xd0;
+            uint8 major;
+            uint8 minor;
+            uint8 revision;
+        }
+//
+//        struct AmqpFrame
+//        {
+//            uint32 size;
+//            uint8 doff;
+//            uint8 type;
+//            uint16 channel;
+//            AmqpPerformative performative;
+//        }
+//
+//        union AmqpPerformative switch (AmqpDescribedType)
+//        {
+//            case OPEN: AmqpOpen open;
+//            case BEGIN: AmqpBegin begin;
+//            case ATTACH: AmqpAttach attach;
+//            case FLOW: AmqpFlow flow;
+//            case TRANSFER: AmqpTransfer transfer;
+//            case DISPOSITION: AmqpDisposition disposition;
+//            case DETACH: AmqpDetach detach;
+//            case END: AmqpEnd end;
+//            case CLOSE: AmqpClose close;
+//        }
+//
+//        variant AmqpValue switch (AmqpType)
+//        {
+//            case DESCRIBED:
+//                AmqpDescribedValue;
+//            case NULL:
+//                AmqpNull;
+//            case BOOLEAN:
+//            case TRUE:
+//            case FALSE:
+//                AmqpBoolean;
+//            case UBYTE:
+//                AmqpUByte;
+//            case USHORT:
+//                AmqpUShort;
+//            case UINT4:
+//            case UINT1:
+//            case UINT0:
+//                AmqpUInt;
+//            case ULONG8:
+//            case ULONG1:
+//            case ULONG0:
+//                AmqpULong;
+//            case BYTE:
+//                AmqpByte;
+//            case SHORT:
+//                AmqpShort;
+//            case INT4:
+//            case INT1:
+//                AmqpInt;
+//            case LONG8:
+//            case LONG1:
+//                AmqpLong;
+//            case FLOAT:
+//                AmqpFloat;
+//            case DOUBLE:
+//                AmqpDouble;
+//            case DECIMAL32:
+//                AmqpDecimal32;
+//            case DECIMAL64:
+//                AmqpDecimal64;
+//            case DECIMAL128:
+//                AmqpDecimal128;
+//            case CHAR:
+//                AmqpChar;
+//            case TIMESTAMP:
+//                AmqpTimestamp;
+//            case UUID:
+//                AmqpUUId;
+//            case BINARY1:
+//            case BINARY4:
+//                AmqpBinary;
+//            case STRING1:
+//            case STRING4:
+//                AmqpString;
+//            case SYMBOL1:
+//            case SYMBOL4:
+//                AmqpSymbol;
+//            case LIST0:
+//            case LIST1:
+//            case LIST4:
+//                AmqpList;
+//            case MAP1:
+//            case MAP4:
+//                AmqpMap;
+//            case ARRAY1:
+//            case ARRAY4:
+//                AmqpArray;
+//        }
+//
+//        enum AmqpType (uint8)
+//        {
+//            DESCRIBED (0x00),
+//            NULL (0x40),
+//            BOOLEAN (0x56),
+//            TRUE (0x41),
+//            FALSE (0x42),
+//            UBYTE (0x50),
+//            USHORT (0x60),
+//            UINT4 (0x70),
+//            UINT1 (0x52),
+//            UINT0 (0x43),
+//            ULONG8 (0x80),
+//            ULONG1 (0x53),
+//            ULONG0 (0x44),
+//            BYTE (0x51),
+//            SHORT (0x61),
+//            INT4 (0x71),
+//            INT1 (0x54),
+//            LONG8 (0x81),
+//            LONG1 (0x55),
+//            FLOAT (0x72),
+//            DOUBLE (0x82),
+//            DECIMAL32 (0x74),
+//            DECIMAL64 (0x84),
+//            DECIMAL128 (0x94),
+//            CHAR (0x73),
+//            TIMESTAMP (0x83),
+//            UUID (0x98),
+//            BINARY1 (0xa0),
+//            BINARY4 (0xb0),
+//            STRING1 (0xa1),
+//            STRING4 (0xb1),
+//            SYMBOL1 (0xa3),
+//            SYMBOL4 (0xb3),
+//            LIST0 (0x45),
+//            LIST1 (0xc0),
+//            LIST4 (0xd0),
+//            MAP1 (0xc1),
+//            MAP4 (0xd1),
+//            ARRAY1 (0xe0),
+//            ARRAY4 (0xf0)
+//        }
+//
+//        enum AmqpDescribedType (AmqpDescriptor)
+//        {
+//            OPEN (0x10L),
+//            BEGIN (0x11L),
+//            ATTACH (0x12L),
+//            FLOW (0x13L),
+//            TRANSFER (0x14L),
+//            DISPOSITION (0x15L),
+//            DETACH (0x16L),
+//            END (0x17L),
+//            CLOSE (0x18L),
+//            ERROR (0x1dL),
+//            HEADER (0x70L),
+//            DELIVERY_ANNOTATIONS (0x71L),
+//            MESSAGE_ANNOTATIONS (0x72L),
+//            PROPERTIES (0x73L),
+//            APPLICATION_PROPERTIES (0x74L),
+//            DATA (0x75L),
+//            SEQUENCE (0x76L),
+//            VALUE (0x77L),
+//            FOOTER (0x78L),
+//            RECEIVED (0x23L),
+//            ACCEPTED (0x24L),
+//            REJECTED (0x25L),
+//            RELEASED (0x26L),
+//            MODIFIED (0x27L),
+//            SOURCE (0x28L),
+//            TARGET (0x29L),
+//            DELETE_ON_CLOSE (0x2bL),
+//            DELETE_ON_NO_LINKS (0x2cL),
+//            DELETE_ON_NO_MESSAGES (0x2dL),
+//            DELETE_ON_NO_LINKS_OR_MESSAGES (0x2eL),
+//            COORDINATOR (0x30L),
+//            DECLARE (0x31L),
+//            DISCHARGE (0x32L),
+//            DECLARED (0x33L),
+//            TRANSACTIONAL_STATE (0x34L),
+//            SASL_MECHANISMS (0x40L),
+//            SASL_INIT (0x41L),
+//            SASL_CHALLENGE (0x42L),
+//            SASL_RESPONSE (0x43L),
+//            SASL_OUTCOME (0x44L)
+//        }
+//
+//        // 1.6 primitive type definitions
+//        variant AmqpNull switch (AmqpType)
+//        {
+//            case NULL: 0;
+//        }
+//
+//        variant AmqpBoolean switch (AmqpType) of uint8
+//        {
+//            case BOOLEAN: uint8;
+//            case TRUE: 1;
+//            case FALSE: 0;
+//        }
+//
+//        variant AmqpUByte switch (AmqpType) of uint8
+//        {
+//            case UBYTE: uint8;
+//        }
+//
+//        variant AmqpUShort switch (AmqpType) of uint16
+//        {
+//            case USHORT: uint16;
+//        }
+//
+//        variant AmqpUInt switch (AmqpType) of uint32
+//        {
+//            case UINT4: uint32;
+//            case UINT1: uint8;
+//            case UINT0: 0;
+//        }
+//
+//        variant AmqpULong switch (AmqpType) of uint64
+//        {
+//            case ULONG8: uint64;
+//            case ULONG1: uint8;
+//            case ULONG0: 0;
+//        }
+//
+//        variant AmqpByte switch (AmqpType) of int8
+//        {
+//            case BYTE: int8;
+//        }
+//
+//        variant AmqpShort switch (AmqpType) of int16
+//        {
+//            case SHORT: int16;
+//        }
+//
+//        variant AmqpInt switch (AmqpType) of int32
+//        {
+//            case INT4: int32;
+//            case INT1: int8;
+//        }
+//
+//        variant AmqpLong switch (AmqpType) of int64
+//        {
+//            case LONG8: int64;
+//            case LONG1: int8;
+//        }
+//
+//        variant AmqpFloat switch (AmqpType)
+//        {
+//            case FLOAT: octets[4];
+//        }
+//
+//        variant AmqpDouble switch (AmqpType)
+//        {
+//            case DOUBLE: octets[8];
+//        }
+//
+//        variant AmqpDecimal32 switch (AmqpType)
+//        {
+//            case DECIMAL32: octets[4];
+//        }
+//
+//        variant AmqpDecimal64 switch (AmqpType)
+//        {
+//            case DECIMAL64: octets[8];
+//        }
+//
+//        variant AmqpDecimal128 switch (AmqpType)
+//        {
+//            case DECIMAL128: octets[16];
+//        }
+//
+//        variant AmqpChar switch (AmqpType)
+//        {
+//            case CHAR: octets[4];
+//        }
+//
+//        variant AmqpTimestamp switch (AmqpType)
+//        {
+//            case TIMESTAMP: int64;
+//        }
+//
+//        variant AmqpUUId switch (AmqpType)
+//        {
+//            case UUID: string16;
+//        }
+//
+//        variant AmqpBinary switch (AmqpType)
+//        {
+//            case BINARY1: octets[uint8];
+//            case BINARY4: octets[uint32];
+//        }
+//
+//        variant AmqpString switch (AmqpType) of string32
+//        {
+//            case STRING1: string;
+//            case STRING4: string32;
+//        }
+//
+//        variant AmqpSymbol switch (AmqpType) of string32
+//        {
+//            case SYMBOL1: string;
+//            case SYMBOL4: string32;
+//        }
+//
+//        variant AmqpList switch (AmqpType) of list
+//        {
+//            case LIST4: list[uint32, uint32, 0x40];
+//            case LIST1: list[uint8, uint8, 0x40];
+//            case LIST0: list[0, 0];
+//        }
+//
+//        variant AmqpMap switch (AmqpType) of map
+//        {
+//            case MAP4: map[uint32];
+//            case MAP1: map[uint8];
+//        }
+//
+//        variant AmqpArray switch (AmqpType) of array
+//        {
+//            case ARRAY4: array[uint32, uint32];
+//            case ARRAY1: array[uint8, uint8];
+//        }
+//
+//        // 2.7 Performatives
+//        list AmqpOpen (AmqpList)
+//        {
+//            required AmqpString containerId; // AmqpString = variant of string32
+//            AmqpString hostname;
+//            AmqpUInt maxFrameSize; // AmqpUInt = variant of uint32
+//            AmqpUShort channelMax; // AmqpUShort = variant of uint16
+//            AmqpMilliseconds idleTimeOut; // AmqpMilliseconds == AmqpUInt
+//            AmqpArray<AmqpIETFLanguageTag> outgoingLocales; // AmqpArray = variant of array, AmqpIETFLanguageTag == AmqpSymbol
+//            AmqpArray<AmqpIETFLanguageTag> incomingLocales;
+//            AmqpArray<AmqpSymbol> offeredCapabilities;
+//            AmqpArray<AmqpSymbol> desiredCapabilities;
+//            AmqpFields<AmqpValue> properties; // AmqpFields<V> == AmqpMap<AmqpSymbol, V>
+//        }
+//
+//        list AmqpBegin (AmqpList)
+//        {
+//            AmqpUShort remoteChannel;
+//            required AmqpTransferNumber nextOutgoingId;
+//            required AmqpUInt incomingWindow;
+//            required AmqpUInt outgoingWindow;
+//            AmqpHandle handleMax;
+//            AmqpArray<AmqpSymbol> offeredCapabilities;
+//            AmqpArray<AmqpSymbol> desiredCapabilities;
+//            AmqpFields<AmqpValue> properties;
+//        }
+//
+//        list AmqpAttach (AmqpList)
+//        {
+//            required AmqpString name;
+//            required AmqpHandle handle;
+//            required AmqpRole role;
+//            AmqpSenderSettleMode sndSettleMode;
+//            AmqpReceiverSettleMode rcvSettleMode;
+//            AmqpSource source;
+//            AmqpTarget target;
+//            AmqpMap unsettled;
+//            AmqpBoolean incompleteUnsettled;
+//            AmqpSequenceNo initialDeliveryCount;
+//            AmqpULong maxMessageSize;
+//            AmqpArray<AmqpSymbol> offeredCapabilities;
+//            AmqpArray<AmqpSymbol> desiredCapabilities;
+//            AmqpFields<AmqpValue> properties;
+//        }
+//
+//        list AmqpFlow (AmqpList)
+//        {
+//            AmqpTransferNumber nextIncomingId;
+//            required AmqpUInt incomingWindow;
+//            required AmqpTransferNumber nextOutgoingId;
+//            required AmqpUInt outgoingWindow;
+//            AmqpHandle handle;
+//            AmqpSequenceNo deliveryCount;
+//            AmqpUInt linkCredit;
+//            AmqpUInt available;
+//            AmqpBoolean drain;
+//            AmqpBoolean echo;
+//            AmqpFields properties;
+//        }
+//
+//        list AmqpTransfer (AmqpList)
+//        {
+//            required AmqpHandle handle;
+//            AmqpDeliveryNumber deliveryId;
+//            AmqpDeliveryTag deliveryTag;
+//            AmqpMessageFormat messageFormat;
+//            AmqpBoolean settled;
+//            AmqpBoolean more;
+//            AmqpReceiverSettleMode rcvSettleMode;
+//            AmqpDeliveryState state;
+//            AmqpBoolean resume;
+//            AmqpBoolean aborted;
+//            AmqpBoolean batchable;
+//        }
+//
+//        list AmqpDisposition (AmqpList)
+//        {
+//            required AmqpRole role;
+//            required AmqpDeliveryNumber first;
+//            AmqpDeliveryNumber last;
+//            AmqpBoolean settled;
+//            AmqpDeliveryState state;
+//            AmqpBoolean batchable;
+//        }
+//
+//        list AmqpDetach (AmqpList)
+//        {
+//            required AmqpHandle handle;
+//            AmqpBoolean closed;
+//            Error error;
+//        }
+//
+//        list AmqpEnd (AmqpList)
+//        {
+//            Error error;
+//        }
+//
+//        list AmqpClose (AmqpList)
+//        {
+//            Error error;
+//        }
+//
+//        // 2.8 Definitions
+//        enum AmqpRole (AmqpBoolean)
+//        {
+//            SENDER (0),
+//            RECEIVER (1)
+//        }
+//
+//        enum AmqpSenderSettleMode (AmqpUByte)
+//        {
+//            UNSETTLED (0),
+//            SETTLED (1),
+//            MIZED (2)
+//        }
+//
+//        enum AmqpReceiverSettleMode (AmqpUByte)
+//        {
+//            FIRST (0),
+//            SECOND (1)
+//        }
+//
+//        typedef AmqpUInt as AmqpHandle;
+//        typedef AmqpUInt as AmqpSeconds;
+//        typedef AmqpUInt as AmqpMilliseconds;
+//        typedef AmqpBinary as AmqpDeliveryTag;
+//        typedef AmqpSequenceNo as AmqpDeliveryNumber;
+//        typedef AmqpSequenceNo as AmqpTransferNumber;
+//        typedef AmqpUInt as AmqpSequenceNo;
+//        typedef AmqpUInt as AmqpMessageFormat;
+//        typedef AmqpSymbol as AmqpIETFLanguageTag;
+//        typedef AmqpMap<AmqpSymbol, V> as AmqpFields<V>;
+//
+//        list AmqpErrorList (AmqpList)
+//        {
+//            required AmqpErrorType condition;
+//            AmqpString description;
+//            AmqpFields info;
+//        }
+//
+//        variant AmqpError switch (AmqpDescribedType+)
+//        {
+//            case ERROR: AmqpErrorList;
+//        }
+//
+//        enum AmqpErrorType (AmqpSymbol)
+//        {
+//            INTERNAL_ERROR ("amqp:internal-error"),
+//            NOT_FOUND ("amqp:not-found"),
+//            UNAUTHORIZED_ACCESS ("amqp:unauthorized-access"),
+//            DECODE_ERROR ("amqp:decode-error"),
+//            RESOURCE_LIMIT_EXCEEDED ("amqp:resource-limit-exceeded"),
+//            NOT_ALLOWED ("amqp:not-allowed"),
+//            INVALID_FIELD ("amqp:invalid-field"),
+//            NOT_IMPLEMENTED ("amqp:not-implemented"),
+//            RESOURCE_LOCKED ("amqp:resource-locked"),
+//            PRECONDITION_FAILED ("amqp:precondition-failed"),
+//            RESOURCE_DELETED ("amqp:resource-deleted"),
+//            ILLEGAL_STATE ("amqp:illegal-state"),
+//            FRAME_SIZE_TOO_SMALL ("amqp:frame-size-too-small"),
+//
+//            CONNECTION_FORCED ("amqp:connection:forced"),
+//            CONNECTION_FRAMING_ERROR ("amqp:connection:framing-error"),
+//            CONNECTION_REDIRECT ("amqp:connection:redirect"),
+//
+//            SESSION_WINDOW_VIOLATION ("amqp:session:window-violation"),
+//            SESSION_ERRANT_LINK ("amqp:session:errant-link"),
+//            SESSION_HANDLE_IN_USE ("amqp:session:handle-in-use"),
+//            SESSION_UNATTACHED_HANDLE ("amqp:session:unattached-handle"),
+//
+//            LINK_DETACH_FORCED ("amqp:link:detach-forced"),
+//            LINK_TRANSFER_LIMIT_EXCEEDED ("amqp:link:transfer-limit-exceeded"),
+//            LINK_MESSAGE_SIZE_EXCEEDED ("amqp:link:message-size-exceeded"),
+//            LINK_REDIRECT ("amqp:link:redirect"),
+//            LINK_STOLEN ("amqp:link:stolen"),
+//
+//            TRANSACTION_UNKNOWN_ID ("amqp:transaction:unknown-id"),
+//            TRANSACTION_ROLLBACK ("amqp:transaction:rollback"),
+//            TRANSACTION_TIMEOUT ("amqp:transaction:timeout")
+//        }
+//
+//        // 3.2 Message Format
+//        union AmqpSection switch (AmqpDescribedType)
+//        {
+//            case HEADER: AmqpHeader header;
+//            case DELIVERY_ANNOTATIONS: AmqpMap deliveryAnnotations;
+//            case MESSAGE_ANNOTATIONS: AmqpMap messageAnnotations;
+//            case PROPERTIES: AmqpProperties properties;
+//            case APPLICATION_PROPERTIES: AmqpMap applicationProperties;
+//            case DATA: AmqpBinary data;
+//            case SEQUENCE: AmqpList amqpSequence;
+//            case VALUE: AmqpValue amqpValue;
+//            case FOOTER: AmqpMap footer;
+//        }
+//
+//        list AmqpHeader (AmqpList)
+//        {
+//            AmqpBoolean durable;
+//            AmqpUByte priority;
+//            AmqpMilliseconds ttl;
+//            AmqpBoolean firstAcquirer;
+//            AmqpUInt deliveryCount;
+//        }
+//
+//        list AmqpProperties (AmqpList)
+//        {
+//            AmqpMessageId messageId;
+//            AmqpBinary userId;
+//            AmqpAddress to;
+//            AmqpString subject;
+//            AmqpAddress replyTo;
+//            AmqpMessageId correlationId;
+//            AmqpSymbol contentType;
+//            AmqpSymbol contentEncoding;
+//            AmqpTimestamp absoluteExpiryTime;
+//            AmqpTimestamp creationTime;
+//            AmqpString groupId;
+//            AmqpSequenceNo group-sequence;
+//            AmqpString replyToGroupId;
+//        }
+//
+//        variant AmqpMessageId switch (AmqpType)
+//        {
+//            case ULONG8:
+//            case ULONG1:
+//            case ULONG0:
+//                AmqpULong;
+//            case UUID:
+//                AmqpUUId;
+//            case BINARY1:
+//            case BINARY4:
+//                AmqpBinary;
+//            case STRING1:
+//            case STRING4:
+//                AmqpString;
+//        }
+//
+//        typedef AmqpString as AmqpAddress;
+//
+//        // 3.4 Delivery state
+//        union AmqpDeliveryState switch (AmqpDescribedType)
+//        {
+//            case RECEIVED: AmqpReceived received;
+//            case ACCEPTED: AmqpList accepted;
+//            case REJECTED: AmqpRejected rejected;
+//            case RELEASED: AmqpReleased AmqpList;
+//            case MODIFIED: AmqpModified modified;
+//            case DECLARED: AmqpDeclared declared;
+//            case TRANSACTIONAL_STATE: AmqpTransactionalState transactionalState;
+//        }
+//
+//        union AmqpOutcome switch (AmqpDescribedType)
+//        {
+//            case ACCEPTED: AmqpList accepted;
+//            case REJECTED: AmqpRejected rejected;
+//            case RELEASED: AmqpReleased AmqpList;
+//            case MODIFIED: AmqpModified modified;
+//            case DECLARED: AmqpDeclared declared;
+//        }
+//
+//        list AmqpReceived (AmqpList)
+//        {
+//            required AmqpUInt sectionNumber;
+//            required AmqpULong sectionOffset;
+//        }
+//
+//        list AmqpRejected (AmqpList)
+//        {
+//            Error error;
+//        }
+//
+//        list AmqpModified (AmqpList)
+//        {
+//            AmqpBoolean deliveryFailed;
+//            AmqpBoolean undeliverableHere;
+//            AmqpFields<AmqpValue> messageAnnotations;
+//        }
+//
+//        // 3.5 Sources and Targets
+//        list AmqpSourceList (AmqpList)
+//        {
+//            AmqpAddress address;
+//            AmqpTerminusDurability durable;
+//            AmqpTerminusExpiryPolicy expiryPolicy;
+//            AmqpSeconds timeout;
+//            AmqpBoolean dynamic;
+//            AmqpNodeProperties dynamicNodeProperties;
+//            AmqpStandardDistributionMode distributionMode;
+//            AmqpFilterSet filter;
+//            AmqpOutcome defaultOutcome;
+//            AmqpArray<AmqpSymbol> outcomes;
+//            AmqpArray<AmqpSymbol> capabilities;
+//        }
+//
+//        variant AmqpSource switch (AmqpDescribedType+)
+//        {
+//            case SOURCE: AmqpSourceList;
+//        }
+//
+//        union AmqpTarget switch (AmqpDescribedType)
+//        {
+//            case TARGET: AmqpTargetList targetList;
+//            case COORDINATOR: AmqpCoordinator coordinatorList;
+//        }
+//
+//        list AmqpTargetList (AmqpList)
+//        {
+//            AmqpAddress address;
+//            AmqpTerminusDurability durable;
+//            AmqpTerminusExpiryPolicy expiryPolicy;
+//            AmqpSeconds timeout;
+//            AmqpBoolean dynamic;
+//            AmqpNodeProperties dynamicNodeProperties;
+//            AmqpArray<AmqpSymbol> capabilities;
+//        }
+//
+//        enum AmqpTerminusDurability (uint8)
+//        {
+//            NONE (0),
+//            CONFIGURATION (1),
+//            UNSETTLED_STATE (2)
+//        }
+//
+//        enum AmqpTerminusExpiryPolicy (AmqpSymbol)
+//        {
+//            LINK_DETACH ("link-detach"),
+//            SESSION_END ("session-end"),
+//            CONNECTION_CLOSE ("connection-close"),
+//            NEVER ("never")
+//        }
+//
+//        enum AmqpStandardDistributionMode (AmqpSymbol)
+//        {
+//            MOVE ("move"),
+//            COPY ("copy")
+//        }
+//
+//        typedef AmqpMap as AmqpFilterSet;
+//        typedef AmqpFields as AmqpNodeProperties;
+//
+//        union AmqpLifetimePolicy switch (AmqpDescribedType)
+//        {
+//            case DELETE_ON_CLOSE: AmqpList deleteOnClose;
+//            case DELETE_ON_NO_LINKS: AmqpList deleteOnNoLinks;
+//            case DELETE_ON_NO_MESSAGES: AmqpList deleteOnNoMessages;
+//            case DELETE_ON_NO_LINKS_OR_MESSAGES: AmqpList deleteOnNoLinksOrMessages;
+//        }
+//
+//        // 4.5 Coordination
+//        list AmqpCoordinator (AmqpList)
+//        {
+//            AmqpArray<AmqpTransactionCapability> capabilities;
+//        }
+//
+//        list AmqpDeclareList (AmqpList)
+//        {
+//            AmqpTxnId globalId;
+//        }
+//
+//        variant AmqpDeclare switch (AmqpDescribedType+)
+//        {
+//            case DECLARE: AmqpDeclareList;
+//        }
+//
+//        list AmqpDischargeList (AmqpList)
+//        {
+//            required AmqpTxnId txnId;
+//            AmqpBoolean fail;
+//        }
+//
+//        variant AmqpDischarge switch (AmqpDescribedType+)
+//        {
+//            case DISCHARGE: AmqpDischargeList;
+//        }
+//
+//        typedef AmqpBinary as AmqpTxnId;
+//
+//        list AmqpDeclared (AmqpList)
+//        {
+//            required AmqpTxnId txnId;
+//        }
+//
+//        list AmqpTransactionalState (AmqpList)
+//        {
+//            required AmqpBinary txnId;
+//            AmqpOutcome outcome;
+//        }
+//
+//        enum AmqpTransactionCapability (AmqpSymbol)
+//        {
+//            LOCAL_TRANSACTIONS ("amqp:local-transactions"),
+//            DISTRIBUTED_TRANSACTIONS ("amqp:distributed-transactions"),
+//            PROMOTABLE_TRANSACTIONS ("amqp:promotable-transactions"),
+//            MULTI_TXNS_PER_SSN ("amqp:multi-txns-per-ssn"),
+//            MULTI_SSNS_PER_TXN ("amqp:multi-ssns-per-txn")
+//        }
+//
+//        // 5.3 Security Frame Bodies
+//        union AmqpSaslFrame switch (AmqpDescribedType)
+//        {
+//            case SASL_MECHANISMS: AmqpSaslMechanisms saslMechanisms;
+//            case SASL_INIT: AmqpSaslInit saslInit;
+//            case SASL_CHALLENGE: AmqpSaslChallenge saslChallenge;
+//            case SASL_RESPONSE: AmqpSaslResponse saslResponse;
+//            case SASL_OUTCOME: AmqpSaslOutcome saslOutcome;
+//        }
+//
+//        list AmqpSaslMechanisms (AmqpList)
+//        {
+//            required AmqpArray<AmqpSymbol> saslServerMechanisms;
+//        }
+//
+//        list AmqpSaslInit (AmqpList)
+//        {
+//            required AmqpSymbol mechanism;
+//            AmqpBinary initialResponse;
+//            AmqpString hostname;
+//        }
+//
+//        list AmqpSaslChallenge (AmqpList)
+//        {
+//            required AmqpBinary challenge;
+//        }
+//
+//        list AmqpSaslResponse (AmqpList)
+//        {
+//            required AmqpBinary response;
+//        }
+//
+//        list AmqpSaslOutcome (AmqpList)
+//        {
+//            required AmqpSaslCode code;
+//            AmqpBinary additionalData;
+//        }
+//
+//        enum AmqpSaslCode (AmqpUByte)
+//        {
+//            OK (0),
+//            AUTH (1),
+//            SYS (2),
+//            SYS_PERM (3),
+//            SYS_TEMP (4)
+//        }
     }
 }

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -17,342 +17,764 @@ scope protocol
 {
     scope codec
     {
-        struct AmqpBinary8
+        variant AmqpDescriptor switch (AmqpType+) as uint64
         {
-            uint8 length;
-            octets[length] bytes;
+            case DESCRIBED: AmqpULong;
         }
 
-        struct AmqpBinary32
+        struct AmqpFrame
         {
-            uint32 length;
-            octets[length] bytes;
-        }
-        
-        union AmqpBoolean switch (uint8)
-        {
-            case 0x56: uint8 booleanType;
-            case 0x41: uint8 trueType; // true TODO: default value?
-            case 0x42: uint8 falseType; // false
+            uint32 size;
+            uint8 doff;
+            uint8 type;
+            uint16 channel;
+            AmqpPerformative performative;
         }
 
-        union AmqpUInt switch (uint8)
+        union AmqpPerformative switch (AmqpDescribedType)
         {
-            case 0x70: uint32 uIntType;
-            case 0x52: uint8 smallUIntType;
-            case 0x43: uint8 uIntZeroType; // uint0 TODO: ideal behavior: case 0x43: ;
+            case OPEN: AmqpOpen open;
+            case BEGIN: AmqpBegin begin;
+            case ATTACH: AmqpAttach attach;
+            case FLOW: AmqpFlow flow;
+            case TRANSFER: AmqpTransfer transfer;
+            case DISPOSITION: AmqpDisposition disposition;
+            case DETACH: AmqpDetach detach;
+            case END: AmqpEnd end;
+            case CLOSE: AmqpClose close;
         }
 
-        union AmqpULong switch (uint8)
+        variant AmqpValue switch (AmqpType)
         {
-            case 0x80: uint64 ulongType;
-            case 0x53: uint8 smallULongType;
-            case 0x44: uint8 uLongZeroType; // ulong0 TODO: ideal behavior: case 0x44: ;
+            case DESCRIBED:
+                AmqpDescribedValue;
+            case NULL:
+                AmqpNull;
+            case BOOLEAN:
+            case TRUE:
+            case FALSE:
+                AmqpBoolean;
+            case UBYTE:
+                AmqpUByte;
+            case USHORT:
+                AmqpUShort;
+            case UINT4:
+            case UINT1:
+            case UINT0:
+                AmqpUInt;
+            case ULONG8:
+            case ULONG1:
+            case ULONG0:
+                AmqpULong;
+            case BYTE:
+                AmqpByte;
+            case SHORT:
+                AmqpShort;
+            case INT4:
+            case INT1:
+                AmqpInt;
+            case LONG8:
+            case LONG1:
+                AmqpLong;
+            case FLOAT:
+                AmqpFloat;
+            case DOUBLE:
+                AmqpDouble;
+            case DECIMAL32:
+                AmqpDecimal32;
+            case DECIMAL64:
+                AmqpDecimal64;
+            case DECIMAL128:
+                AmqpDecimal128;
+            case CHAR:
+                AmqpChar;
+            case TIMESTAMP:
+                AmqpTimestamp;
+            case UUID:
+                AmqpUUId;
+            case BINARY1:
+            case BINARY4:
+                AmqpBinary;
+            case STRING1:
+            case STRING4:
+                AmqpString;
+            case SYMBOL1:
+            case SYMBOL4:
+                AmqpSymbol;
+            case LIST0:
+            case LIST1:
+            case LIST4:
+                AmqpList;
+            case MAP1:
+            case MAP4:
+                AmqpMap;
+            case ARRAY1:
+            case ARRAY4:
+                AmqpArray;
         }
 
-        union AmqpInt switch (uint8)
+        enum AmqpType (uint8)
         {
-            case 0x71: int32 intType;
-            case 0x54: int8 smallIntType;
+            DESCRIBED (0x00),
+            NULL (0x40),
+            BOOLEAN (0x56),
+            TRUE (0x41),
+            FALSE (0x42),
+            UBYTE (0x50),
+            USHORT (0x60),
+            UINT4 (0x70),
+            UINT1 (0x52),
+            UINT0 (0x43),
+            ULONG8 (0x80),
+            ULONG1 (0x53),
+            ULONG0 (0x44),
+            BYTE (0x51),
+            SHORT (0x61),
+            INT4 (0x71),
+            INT1 (0x54),
+            LONG8 (0x81),
+            LONG1 (0x55),
+            FLOAT (0x72),
+            DOUBLE (0x82),
+            DECIMAL32 (0x74),
+            DECIMAL64 (0x84),
+            DECIMAL128 (0x94),
+            CHAR (0x73),
+            TIMESTAMP (0x83),
+            UUID (0x98),
+            BINARY1 (0xa0),
+            BINARY4 (0xb0),
+            STRING1 (0xa1),
+            STRING4 (0xb1),
+            SYMBOL1 (0xa3),
+            SYMBOL4 (0xb3),
+            LIST0 (0x45),
+            LIST1 (0xc0),
+            LIST4 (0xd0),
+            MAP1 (0xc1),
+            MAP4 (0xd1),
+            ARRAY1 (0xe0),
+            ARRAY4 (0xf0)
         }
 
-        union AmqpLong switch (uint8)
+        enum AmqpDescribedType (AmqpDescriptor)
         {
-            case 0x81: int64 longType;
-            case 0x55: int8 smallLongType;
+            OPEN (0x10L),
+            BEGIN (0x11L),
+            ATTACH (0x12L),
+            FLOW (0x13L),
+            TRANSFER (0x14L),
+            DISPOSITION (0x15L),
+            DETACH (0x16L),
+            END (0x17L),
+            CLOSE (0x18L),
+            ERROR (0x1dL),
+            HEADER (0x70L),
+            DELIVERY_ANNOTATIONS (0x71L),
+            MESSAGE_ANNOTATIONS (0x72L),
+            PROPERTIES (0x73L),
+            APPLICATION_PROPERTIES (0x74L),
+            DATA (0x75L),
+            AMQP_SEQUENCE (0x76L),
+            AMQP_VALUE (0x77L),
+            FOOTER (0x78L),
+            RECEIVED (0x23L),
+            ACCEPTED (0x24L),
+            REJECTED (0x25L),
+            RELEASED (0x26L),
+            MODIFIED (0x27L),
+            SOURCE (0x28L),
+            TARGET (0x29L),
+            DELETE_ON_CLOSE (0x2bL),
+            DELETE_ON_NO_LINKS (0x2cL),
+            DELETE_ON_NO_MESSAGES (0x2dL),
+            DELETE_ON_NO_LINKS_OR_MESSAGES (0x2eL),
+            COORDINATOR (0x30L),
+            DECLARE (0x31L),
+            DISCHARGE (0x32L),
+            DECLARED (0x33L),
+            TRANSACTIONAL_STATE (0x34L),
+            SASL_MECHANISMS (0x40L),
+            SASL_INIT (0x41L),
+            SASL_CHALLENGE (0x42L),
+            SASL_RESPONSE (0x43L),
+            SASL_OUTCOME (0x44L),
         }
 
-        union AmqpBinary switch (uint8)
+        // 1.6 primitive type definitions
+        variant AmqpNull switch (AmqpType)
         {
-            case 0xa0: protocol::codec::AmqpBinary8 vbin8;
-            case 0xb0: protocol::codec::AmqpBinary32 vbin32;
+            case NULL: 0;
         }
 
-        union AmqpString switch (uint8)
+        variant AmqpBoolean switch (AmqpType) of uint8
         {
-            case 0xa1: string str8;
-            case 0xb1: string32 str32; // TODO: string32 not currently supported
+            case BOOLEAN: uint8;
+            case TRUE: 1;
+            case FALSE: 0;
         }
 
-        union AmqpSymbol switch (uint8)
+        variant AmqpUByte switch (AmqpType) of uint8
         {
-            case 0xa3: string sym8;
-            case 0xb3: string32 sym32; // TODO: string32 not currently supported
+            case UBYTE: uint8;
         }
 
-        union AmqpList switch (uint8)
+        variant AmqpUShort switch (AmqpType) of uint16
         {
-            case 0x45: int8 listZero; // list0 TODO: ideal behavior: case 0x45: ;
-            case 0xc0: // TODO: need to design
-            case 0xd0: // TODO: need to design
+            case USHORT: uint16;
         }
 
-        union AmqpMap switch (uint8) // TODO:
+        variant AmqpUInt switch (AmqpType) of uint32
         {
-            case 0xc1: list<protocol::codec::AmqpKeyValue> map8;
-            case 0xd1: list<protocol::codec::AmqpKeyValue> map32;
+            case UINT4: uint32;
+            case UINT1: uint8;
+            case UINT0: 0;
         }
 
-        struct AmqpKeyValue
+        variant AmqpULong switch (AmqpType) of uint64
         {
-            protocol::codec::AmqpSymbol key;
-            protocol::codec::AmqpSymbol value;
+            case ULONG8: uint64;
+            case ULONG1: uint8;
+            case ULONG0: 0;
         }
 
-        struct AmqpProperty
+        variant AmqpByte switch (AmqpType) of int8
         {
-            protocol::codec::AmqpSymbol key;
-            protocol::codec::AmqpSymbol value; // TODO: not sure about the type
+            case BYTE: int8;
         }
 
-        // 2.8 Definitions
-        enum AmqpRole
+        variant AmqpShort switch (AmqpType) of int16
         {
-            SENDER,
-            RECEIVER
+            case SHORT: int16;
         }
 
-        enum AmqpSenderSettleMode
+        variant AmqpInt switch (AmqpType) of int32
         {
-            UNSETTLED,
-            SETTLED,
-            MIZED
+            case INT4: int32;
+            case INT1: int8;
         }
 
-        enum AmqpReceiverSettleMode
+        variant AmqpLong switch (AmqpType) of int64
         {
-            FIRST,
-            SECOND
+            case LONG8: int64;
+            case LONG1: int8;
         }
 
-        struct Error
+        variant AmqpFloat switch (AmqpType)
         {
-            protocol::codec::AmqpError condition;
-            protocol::codec::AmqpString description;
-            protocol::codec::AmqpMap info;
+            case FLOAT: octets[4];
         }
 
-        enum AmqpError // TODO: values are symbol - need to store values associated with names
+        variant AmqpDouble switch (AmqpType)
         {
-             INTERNAL_ERROR,
-             NOT_FOUND,
-             UNAUTHORIZED_ACCESS,
-             DECODE_ERROR,
-             RESOURCE_LIMIT_EXCEEDED,
-             NOT_ALLOWED,
-             INVALID_FIELD,
-             NOT_IMPLEMENTED,
-             RESOURCE_LOCKED,
-             PRECONDITION_FAILED,
-             RESOURCE_DELETED,
-             ILLEGAL_STATE,
-             FRAME_SIZE_TOO_SMALL
+            case DOUBLE: octets[8];
         }
 
-        // 3.4 Delivery state
-        union AmqpDeliveryState switch (uint8)
+        variant AmqpDecimal32 switch (AmqpType)
         {
-            case 0x23: protocol::codec::AmqpReceived received;
-            case 0x24: protocol::codec::AmqpList accepted; // TODO: should be empty list
-            case 0x25: protocol::codec::AmqpRejected rejected;
-            case 0x26: protocol::codec::AmqpList released; // TODO: should be empty list
-            case 0x27: protocol::codec::AmqpModified modified;
-            case 0x33: protocol::codec::AmqpDeclared declared;
-            case 0x34: protocol::codec::AmqpTransactionalState transactionalState;
+            case DECIMAL32: octets[4];
         }
 
-        union AmqpOutcome switch (uint8)
+        variant AmqpDecimal64 switch (AmqpType)
         {
-            case 0x24: protocol::codec::AmqpList accepted; // TODO: should be empty list
-            case 0x25: protocol::codec::AmqpRejected rejected;
-            case 0x26: protocol::codec::AmqpList released; // TODO: should be empty list
-            case 0x27: protocol::codec::AmqpModified modified;
-            case 0x33: protocol::codec::AmqpDeclared declared;
+            case DECIMAL64: octets[8];
         }
 
-        struct AmqpReceived
+        variant AmqpDecimal128 switch (AmqpType)
         {
-            protocol::codec::AmqpUInt sectionNumber; // required
-            protocol::codec::AmqpULong sectionOffset; // required
+            case DECIMAL128: octets[16];
         }
 
-        struct AmqpRejected
+        variant AmqpChar switch (AmqpType)
         {
-            protocol::codec::Error error;
+            case CHAR: octets[4];
         }
 
-        struct AmqpDeclared
+        variant AmqpTimestamp switch (AmqpType)
         {
-            protocol::codec::AmqpBinary txnId; // required
+            case TIMESTAMP: int64;
         }
 
-        struct AmqpModified
+        variant AmqpUUId switch (AmqpType)
         {
-            protocol::codec::AmqpBoolean deliveryFailed;
-            protocol::codec::AmqpBoolean undeliverableHere;
-            protocol::codec::AmqpMap messageAnnotations;
+            case UUID: string16;
         }
 
-        struct AmqpTransactionalState
+        variant AmqpBinary switch (AmqpType)
         {
-            protocol::codec::AmqpBinary txnId; // required
-            protocol::codec::AmqpOutcome outcome;
+            case BINARY1: octets[uint8];
+            case BINARY4: octets[uint32];
         }
 
-        // 3.5 Sources and Targets
-        struct AmqpSource
+        variant AmqpString switch (AmqpType) of string32
         {
-            protocol::codec::AmqpString address;
-            protocol::codec::AmqpTerminusDurability durable;
-            protocol::codec::AmqpTerminusExpiryPolicy expiryPolicy;
-            protocol::codec::AmqpUInt timeout;
-            protocol::codec::AmqpBoolean dynamic;
-            protocol::codec::AmqpMap dynamicNodeProperties;
-            protocol::codec::AmqpStandardDistributionMode distributionMode;
-            protocol::codec::AmqpMap filter;
-            protocol::codec::AmqpOutcome defaultOutcome;
-            list<protocol::codec::AmqpSymbol> outcomes;
-            list<protocol::codec::AmqpSymbol> capabilities;
+            case STRING1: string;
+            case STRING4: string32;
         }
 
-        struct AmqpTarget
+        variant AmqpSymbol switch (AmqpType) of string32
         {
-            protocol::codec::AmqpString address;
-            protocol::codec::AmqpTerminusDurability durable;
-            protocol::codec::AmqpTerminusExpiryPolicy expiryPolicy;
-            protocol::codec::AmqpUInt timeout;
-            protocol::codec::AmqpBoolean dynamic;
-            protocol::codec::AmqpMap dynamicNodeProperties;
-            list<protocol::codec::AmqpSymbol> capabilities;
+            case SYMBOL1: string;
+            case SYMBOL4: string32;
         }
 
-        enum AmqpTerminusDurability
+        variant AmqpList switch (AmqpType) of list
         {
-            NONE,
-            CONFIGURATION,
-            UNSETTLED_STATE
+            case LIST4: list[uint32, uint32];
+            case LIST1: list[uint8, uint8];
+            case LIST0: list[0, 0];
         }
 
-        enum AmqpTerminusExpiryPolicy // TODO: values are symbol
+        variant AmqpMap switch (AmqpType) of map
         {
-            LINK_DETACH,
-            SESSION_END,
-            CONNECTION_CLOSE,
-            NEVER
+            case MAP4: map[uint32];
+            case MAP1: map[uint8];
         }
 
-        enum AmqpStandardDistributionMode // TODO: values are symbol
+        variant AmqpArray switch (AmqpType) of array
         {
-            MOVE,
-            COPY
+            case ARRAY4: array[uint32, uint32];
+            case ARRAY1: array[uint8, uint8];
         }
 
         // 2.7 Performatives
-        struct AmqpOpenFrame // TODO: struct requires all the properties --> need optional fields
+        list AmqpOpen (AmqpList)
         {
-            protocol::codec::AmqpString containerId; // required
-            protocol::codec::AmqpString hostname;
-            protocol::codec::AmqpUInt maxFrameSize;
-            uint16 channelMax;
-            protocol::codec::AmqpUInt idleTimeOut;
-            list<protocol::codec::AmqpSymbol> outgoingLocales;
-            list<protocol::codec::AmqpSymbol> incomingLocales;
-            list<protocol::codec::AmqpSymbol> offeredCapabilities;
-            list<protocol::codec::AmqpSymbol> desiredCapabilities;
-            list<protocol::codec::AmqpProperty> properties; // TODO: key is symbol and value can be any
+            required AmqpString containerId;
+            AmqpString hostname;
+            AmqpUInt maxFrameSize;
+            AmqpUShort channelMax;
+            AmqpMilliseconds idleTimeOut;
+            AmqpArray<AmqpIETFLanguageTag> outgoingLocales;
+            AmqpArray<AmqpIETFLanguageTag> incomingLocales;
+            AmqpArray<AmqpSymbol> offeredCapabilities;
+            AmqpArray<AmqpSymbol> desiredCapabilities;
+            AmqpFields<AmqpValue> properties;
         }
 
-        struct AmqpBeginFrame
+        list AmqpBegin (AmqpList)
         {
-            uint16 remoteChannel;
-            uint32 nextOutgoingId; // required
-            protocol::codec::AmqpUInt incomingWindow; // required
-            protocol::codec::AmqpUInt outgoingWindow; // required
-            protocol::codec::AmqpUInt handleMax;
-            list<protocol::codec::AmqpSymbol> offeredCapabilities;
-            list<protocol::codec::AmqpSymbol> desiredCapabilities;
-            list<protocol::codec::AmqpProperty> properties;
+            AmqpUShort remoteChannel;
+            required AmqpTransferNumber nextOutgoingId;
+            required AmqpUInt incomingWindow;
+            required AmqpUInt outgoingWindow;
+            AmqpHandle handleMax;
+            AmqpArray<AmqpSymbol> offeredCapabilities;
+            AmqpArray<AmqpSymbol> desiredCapabilities;
+            AmqpFields<AmqpValue> properties;
         }
 
-        struct AmqpAttachFrame
+        list AmqpAttach (AmqpList)
         {
-            protocol::codec::AmqpString name; // required
-            protocol::codec::AmqpUInt handle; // required
-            protocol::codec::AmqpRole role; // required
-            protocol::codec::AmqpSenderSettleMode sndSettleMode;
-            protocol::codec::AmqpReceiverSettleMode rcvSettleMode;
-            protocol::codec::AmqpSource source;
-            protocol::codec::AmqpTarget target;
-            protocol::codec::AmqpMap unsettled;
-            protocol::codec::AmqpBoolean incompleteUnsettled;
-            protocol::codec::AmqpUInt initialDeliveryCount;
-            protocol::codec::AmqpULong maxMessageSize;
-            list<protocol::codec::AmqpSymbol> offeredCapabilities;
-            list<protocol::codec::AmqpSymbol> desiredCapabilities;
-            list<protocol::codec::AmqpProperty> properties;
+            required AmqpString name;
+            required AmqpHandle handle;
+            required AmqpRole role;
+            AmqpSenderSettleMode sndSettleMode;
+            AmqpReceiverSettleMode rcvSettleMode;
+            AmqpSource source;
+            AmqpTarget target;
+            AmqpMap unsettled;
+            AmqpBoolean incompleteUnsettled;
+            AmqpSequenceNo initialDeliveryCount;
+            AmqpULong maxMessageSize;
+            AmqpArray<AmqpSymbol> offeredCapabilities;
+            AmqpArray<AmqpSymbol> desiredCapabilities;
+            AmqpFields<AmqpValue> properties;
         }
 
-        struct AmqpFlowFrame
+        list AmqpFlow (AmqpList)
         {
-            protocol::codec::AmqpUInt nextIncomingId;
-            protocol::codec::AmqpUInt incomingWindow; // required
-            protocol::codec::AmqpUInt nextOutgoingId; // required
-            protocol::codec::AmqpUInt outgoingWindow;  // required
-            protocol::codec::AmqpUInt handle;
-            protocol::codec::AmqpUInt deliveryCount;
-            protocol::codec::AmqpUInt linkCredit;
-            protocol::codec::AmqpUInt available;
-            protocol::codec::AmqpBoolean drain;
-            protocol::codec::AmqpBoolean echo;
-            list<protocol::codec::AmqpProperty> properties;
+            AmqpTransferNumber nextIncomingId;
+            required AmqpUInt incomingWindow;
+            required AmqpTransferNumber nextOutgoingId;
+            required AmqpUInt outgoingWindow;
+            AmqpHandle handle;
+            AmqpSequenceNo deliveryCount;
+            AmqpUInt linkCredit;
+            AmqpUInt available;
+            AmqpBoolean drain;
+            AmqpBoolean echo;
+            AmqpFields properties;
         }
 
-        struct AmqpTransferFrame
+        list AmqpTransfer (AmqpList)
         {
-            protocol::codec::AmqpUInt handle; // required
-            protocol::codec::AmqpUInt deliveryId;
-            protocol::codec::AmqpBinary deliveryTag;
-            protocol::codec::AmqpMessageFormat messageFormat;
-            protocol::codec::AmqpBoolean settled;
-            protocol::codec::AmqpBoolean more;
-            protocol::codec::AmqpReceiverSettleMode rcvSettleMode;
-            protocol::codec::AmqpDeliveryState state;
-            protocol::codec::AmqpBoolean resume;
-            protocol::codec::AmqpBoolean aborted;
-            protocol::codec::AmqpBoolean batchable;
+            required AmqpHandle handle;
+            AmqpDeliveryNumber deliveryId;
+            AmqpDeliveryTag deliveryTag;
+            AmqpMessageFormat messageFormat;
+            AmqpBoolean settled;
+            AmqpBoolean more;
+            AmqpReceiverSettleMode rcvSettleMode;
+            AmqpDeliveryState state;
+            AmqpBoolean resume;
+            AmqpBoolean aborted;
+            AmqpBoolean batchable;
         }
 
-        struct AmqpDispositionFrame
+        list AmqpDisposition (AmqpList)
         {
-            protocol::codec::AmqpRole role; // required
-            protocol::codec::AmqpUInt first; // required
-            protocol::codec::AmqpUInt last;
-            protocol::codec::AmqpBoolean settled;
-            protocol::codec::AmqpDeliveryState state;
-            protocol::codec::AmqpBoolean batchable;
+            required AmqpRole role;
+            required AmqpDeliveryNumber first;
+            AmqpDeliveryNumber last;
+            AmqpBoolean settled;
+            AmqpDeliveryState state;
+            AmqpBoolean batchable;
         }
 
-        struct AmqpDetachFrame
+        list AmqpDetach (AmqpList)
         {
-            protocol::codec::AmqpUInt handle; // required
-            protocol::codec::AmqpBoolean closed;
-            protocol::codec::Error error;
+            required AmqpHandle handle;
+            AmqpBoolean closed;
+            Error error;
         }
 
-        struct AmqpEndFrame
+        list AmqpEnd (AmqpList)
         {
-            protocol::codec::Error error;
+            Error error;
         }
 
-        struct AmqpCloseFrame
+        list AmqpClose (AmqpList)
         {
-            protocol::codec::Error error;
+            Error error;
         }
 
-        struct AmqpMessageFormat
+        // 2.8 Definitions
+        enum AmqpRole (AmqpBoolean)
         {
-            octets[3] messageFormat;
-            octets[1] version;
+            SENDER (0),
+            RECEIVER (1)
+        }
+
+        enum AmqpSenderSettleMode (AmqpUByte)
+        {
+            UNSETTLED (0),
+            SETTLED (1),
+            MIZED (2)
+        }
+
+        enum AmqpReceiverSettleMode (AmqpUByte)
+        {
+            FIRST (0),
+            SECOND (1)
+        }
+
+        typedef AmqpUInt as AmqpHandle;
+        typedef AmqpUInt as AmqpSeconds;
+        typedef AmqpUInt as AmqpMilliseconds;
+        typedef AmqpBinary as AmqpDeliveryTag;
+        typedef AmqpSequenceNo as AmqpDeliveryNumber;
+        typedef AmqpSequenceNo as AmqpTransferNumber;
+        typedef AmqpUInt as AmqpSequenceNo;
+        typedef AmqpUInt as AmqpMessageFormat;
+        typedef AmqpSymbol as AmqpIETFLanguageTag;
+        typedef AmqpMap<AmqpSymbol, V> as AmqpFields<V>;
+
+        list ErrorList (AmqpList)
+        {
+            required AmqpErrorType condition;
+            AmqpString description;
+            AmqpFields info;
+        }
+
+        variant AmqpError switch (AmqpDescribedType+)
+        {
+            case ERROR: ErrorList;
+        }
+
+        enum AmqpErrorType (AmqpSymbol)
+        {
+            INTERNAL_ERROR ("amqp:internal-error"),
+            NOT_FOUND ("amqp:not-found"),
+            UNAUTHORIZED_ACCESS ("amqp:unauthorized-access"),
+            DECODE_ERROR ("amqp:decode-error"),
+            RESOURCE_LIMIT_EXCEEDED ("amqp:resource-limit-exceeded"),
+            NOT_ALLOWED ("amqp:not-allowed"),
+            INVALID_FIELD ("amqp:invalid-field"),
+            NOT_IMPLEMENTED ("amqp:not-implemented"),
+            RESOURCE_LOCKED ("amqp:resource-locked"),
+            PRECONDITION_FAILED ("amqp:precondition-failed"),
+            RESOURCE_DELETED ("amqp:resource-deleted"),
+            ILLEGAL_STATE ("amqp:illegal-state"),
+            FRAME_SIZE_TOO_SMALL ("amqp:frame-size-too-small"),
+            CONNECTION_FORCED ("amqp:connection:forced"),
+            CONNECTION_FRAMING_ERROR ("amqp:connection:framing-error"),
+            CONNECTION_REDIRECT ("amqp:connection:redirect"),
+            SESSION_WINDOW_VIOLATION ("amqp:session:window-violation"),
+            SESSION_ERRANT_LINK ("amqp:session:errant-link"),
+            SESSION_HANDLE_IN_USE ("amqp:session:handle-in-use"),
+            SESSION_UNATTACHED_HANDLE ("amqp:session:unattached-handle"),
+            LINK_DETACH_FORCED ("amqp:link:detach-forced"),
+            LINK_TRANSFER_LIMIT_EXCEEDED ("amqp:link:transfer-limit-exceeded"),
+            LINK_MESSAGE_SIZE_EXCEEDED ("amqp:link:message-size-exceeded"),
+            LINK_REDIRECT ("amqp:link:redirect"),
+            LINK_STOLEN ("amqp:link:stolen"),
+            TRANSACTION_UNKNOWN_ID ("amqp:transaction:unknown-id"),
+            TRANSACTION_ROLLBACK ("amqp:transaction:rollback"),
+            TRANSACTION_TIMEOUT ("amqp:transaction:timeout")
+        }
+
+        // 3.2 Message Format
+        union AmqpSection switch (AmqpDescribedType)
+        {
+            case HEADER: AmqpHeader header;
+            case DELIVERY_ANNOTATIONS: AmqpMap deliveryAnnotations;
+            case MESSAGE_ANNOTATIONS: AmqpMap messageAnnotations;
+            case PROPERTIES: AmqpProperties properties;
+            case APPLICATION_PROPERTIES: AmqpMap applicationProperties;
+            case DATA: AmqpBinary data;
+            case AMQP_SEQUENCE: AmqpList amqpSequence;
+            case AMQP_VALUE: AmqpValue amqpValue;
+            case FOOTER: AmqpMap footer;
+        }
+
+        list AmqpHeader (AmqpList)
+        {
+            AmqpBoolean durable;
+            AmqpUByte priority;
+            AmqpMilliseconds ttl;
+            AmqpBoolean firstAcquirer;
+            AmqpUInt deliveryCount;
+        }
+
+        list AmqpProperties (AmqpList)
+        {
+            AmqpMessageId messageId;
+            AmqpBinary userId;
+            AmqpAddress to;
+            AmqpString subject;
+            AmqpAddress replyTo;
+            AmqpMessageId correlationId;
+            AmqpSymbol contentType;
+            AmqpSymbol contentEncoding;
+            AmqpTimestamp absoluteExpiryTime;
+            AmqpTimestamp creationTime;
+            AmqpString groupId;
+            AmqpSequenceNo group-sequence;
+            AmqpString replyToGroupId;
+        }
+
+        variant AmqpMessageId switch (AmqpType)
+        {
+            case ULONG8:
+            case ULONG1:
+            case ULONG0:
+                AmqpULong;
+            case UUID:
+                AmqpUUId;
+            case BINARY1:
+            case BINARY4:
+                AmqpBinary;
+            case STRING1:
+            case STRING4:
+                AmqpString;
+        }
+
+        typedef AmqpString as AmqpAddress;
+
+        // 3.4 Delivery state
+        union AmqpDeliveryState switch (AmqpDescribedType)
+        {
+            case RECEIVED: AmqpReceived received;
+            case ACCEPTED: AmqpList accepted;
+            case REJECTED: AmqpRejected rejected;
+            case RELEASED: AmqpReleased AmqpList;
+            case MODIFIED: AmqpModified modified;
+            case DECLARED: AmqpDeclared declared;
+            case TRANSACTIONAL_STATE: AmqpTransactionalState transactionalState;
+        }
+
+        union AmqpOutcome switch (AmqpDescribedType)
+        {
+            case ACCEPTED: AmqpList accepted;
+            case REJECTED: AmqpRejected rejected;
+            case RELEASED: AmqpReleased AmqpList;
+            case MODIFIED: AmqpModified modified;
+            case DECLARED: AmqpDeclared declared;
+        }
+
+        list AmqpReceived (AmqpList)
+        {
+            required AmqpUInt sectionNumber;
+            required AmqpULong sectionOffset;
+        }
+
+        list AmqpRejected (AmqpList)
+        {
+            Error error;
+        }
+
+        list AmqpModified (AmqpList)
+        {
+            AmqpBoolean deliveryFailed;
+            AmqpBoolean undeliverableHere;
+            AmqpFields<AmqpValue> messageAnnotations;
+        }
+
+        // 3.5 Sources and Targets
+        list AmqpSourceList (AmqpList)
+        {
+            AmqpAddress address;
+            AmqpTerminusDurability durable;
+            AmqpTerminusExpiryPolicy expiryPolicy;
+            AmqpSeconds timeout;
+            AmqpBoolean dynamic;
+            AmqpNodeProperties dynamicNodeProperties;
+            AmqpStandardDistributionMode distributionMode;
+            AmqpFilterSet filter;
+            AmqpOutcome defaultOutcome;
+            AmqpArray<AmqpSymbol> outcomes;
+            AmqpArray<AmqpSymbol> capabilities;
+        }
+
+        variant AmqpSource switch (AmqpDescribedType+)
+        {
+            case SOURCE: AmqpSourceList;
+        }
+
+        union AmqpTarget switch (AmqpDescribedType)
+        {
+            case TARGET: AmqpTargetList targetList;
+            case COORDINATOR: AmqpCoordinator coordinatorList;
+        }
+
+        list AmqpTargetList (AmqpList)
+        {
+            AmqpAddress address;
+            AmqpTerminusDurability durable;
+            AmqpTerminusExpiryPolicy expiryPolicy;
+            AmqpSeconds timeout;
+            AmqpBoolean dynamic;
+            AmqpNodeProperties dynamicNodeProperties;
+            AmqpArray<AmqpSymbol> capabilities;
+        }
+
+        enum AmqpTerminusDurability (uint8)
+        {
+            NONE (0),
+            CONFIGURATION (1),
+            UNSETTLED_STATE (2)
+        }
+
+        enum AmqpTerminusExpiryPolicy (AmqpSymbol)
+        {
+            LINK_DETACH ("link-detach"),
+            SESSION_END ("session-end"),
+            CONNECTION_CLOSE ("connection-close"),
+            NEVER ("never")
+        }
+
+        enum AmqpStandardDistributionMode (AmqpSymbol)
+        {
+            MOVE ("move"),
+            COPY ("copy")
+        }
+
+        typedef AmqpMap as AmqpFilterSet;
+        typedef AmqpFields as AmqpNodeProperties;
+
+        union AmqpLifetimePolicy switch (AmqpDescribedType)
+        {
+            case DELETE_ON_CLOSE: AmqpList deleteOnClose;
+            case DELETE_ON_NO_LINKS: AmqpList deleteOnNoLinks;
+            case DELETE_ON_NO_MESSAGES: AmqpList deleteOnNoMessages;
+            case DELETE_ON_NO_LINKS_OR_MESSAGES: AmqpList deleteOnNoLinksOrMessages;
+        }
+
+        // 4.5 Coordination
+        list AmqpCoordinator (AmqpList)
+        {
+            AmqpArray<AmqpTransactionCapability> capabilities;
+        }
+
+        list AmqpDeclareList (AmqpList)
+        {
+            AmqpTxnId globalId;
+        }
+
+        variant AmqpDeclare switch (AmqpDescribedType+)
+        {
+            case DECLARE: AmqpDeclareList;
+        }
+
+        list AmqpDischargeList (AmqpList)
+        {
+            required AmqpTxnId txnId;
+            AmqpBoolean fail;
+        }
+
+        variant AmqpDischarge switch (AmqpDescribedType+)
+        {
+            case DISCHARGE: AmqpDischargeList;
+        }
+
+        typedef AmqpBinary as AmqpTxnId;
+
+        list AmqpDeclared (AmqpList)
+        {
+            required AmqpTxnId txnId;
+        }
+
+        list AmqpTransactionalState (AmqpList)
+        {
+            required AmqpBinary txnId;
+            AmqpOutcome outcome;
+        }
+
+        enum AmqpTransactionCapability (AmqpSymbol)
+        {
+            LOCAL_TRANSACTIONS ("amqp:local-transactions"),
+            DISTRIBUTED_TRANSACTIONS ("amqp:distributed-transactions"),
+            PROMOTABLE_TRANSACTIONS ("amqp:promotable-transactions"),
+            MULTI_TXNS_PER_SSN ("amqp:multi-txns-per-ssn"),
+            MULTI_SSNS_PER_TXN ("amqp:multi-ssns-per-txn")
+        }
+
+        // 5.3 Security Frame Bodies
+        union AmqpSaslFrame switch (AmqpDescribedType)
+        {
+            case SASL_MECHANISMS: AmqpSaslMechanisms saslMechanisms;
+            case SASL_INIT: AmqpSaslInit saslInit;
+            case SASL_CHALLENGE: AmqpSaslChallenge saslChallenge;
+            case SASL_RESPONSE: AmqpSaslResponse saslResponse;
+            case SASL_OUTCOME: AmqpSaslOutcome saslOutcome;
+        }
+
+        list AmqpSaslMechanisms (AmqpList)
+        {
+            required AmqpArray<AmqpSymbol> saslServerMechanisms;
+        }
+
+        list AmqpSaslInit (AmqpList)
+        {
+            required AmqpSymbol mechanism;
+            AmqpBinary initialResponse;
+            AmqpString hostname;
+        }
+
+        list AmqpSaslChallenge (AmqpList)
+        {
+            required AmqpBinary challenge;
+        }
+
+        list AmqpSaslResponse (AmqpList)
+        {
+            required AmqpBinary response;
+        }
+
+        list AmqpSaslOutcome (AmqpList)
+        {
+            required AmqpSaslCode code;
+            AmqpBinary additionalData;
+        }
+
+        enum AmqpSaslCode (AmqpUByte)
+        {
+            OK (0),
+            AUTH (1),
+            SYS (2),
+            SYS_PERM (3),
+            SYS_TEMP (4)
         }
     }
 }

--- a/src/main/reaktivity/protocol.idl
+++ b/src/main/reaktivity/protocol.idl
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+scope protocol
+{
+    scope codec
+    {
+        struct AmqpBinaryData
+        {
+            uint16 length;
+            octets[length] bytes;
+        }
+        
+        union AmqpBoolean switch (uint8)
+        {
+            case 0x56: uint8 boolean;
+            case 0x41: uint8 true; // true TODO: default value?
+            case 0x42: uint8 false; // false
+        }
+
+        union AmqpUInt switch (uint8)
+        {
+            case 0x70: uint32 uint;
+            case 0x52: uint8 smalluint;
+            case 0x43: uint8 uIntZero; // uint0 TODO: ideal behavior: case 0x43: ;
+        }
+
+        union AmqpULong switch (uint8)
+        {
+            case 0x80: uint64 ulong;
+            case 0x53: uint8 smallulong;
+            case 0x44: uint8 uLongZero; // ulong0 TODO: ideal behavior: case 0x44: ;
+        }
+
+        union AmqpInt switch (uint8)
+        {
+            case 0x71: int32 int;
+            case 0x54: int8 smallint;
+        }
+
+        union AmqpLong switch (uint8)
+        {
+            case 0x81: int64 long;
+            case 0x55: int8 smalllong;
+        }
+
+        union AmqpBinary switch (uint8)
+        {
+            case 0xa0: protocol::codec::AmqpBinaryData vbin8;
+            case 0xb0: protocol::codec::AmqpBinaryData vbin32;
+        }
+
+        union AmqpString switch (uint8)
+        {
+            case 0xa1: protocol::codec::AmqpBinaryData str8;
+            case 0xb1: protocol::codec::AmqpBinaryData str32;
+        }
+
+        union AmqpSymbol switch (uint8)
+        {
+            case 0xa3: protocol::codec::AmqpBinaryData sym8;
+            case 0xb3: string sym32;
+        }
+
+        union AmqpList switch (uint8)
+        {
+            case 0x45: int8 listZero; // list0 TODO: ideal behavior: case 0x45: ;
+            case 0xc0: protocol::codec::AmqpBinaryData list8;
+            case 0xd0: protocol::codec::AmqpBinaryData list32;
+        }
+
+        union AmqpMap switch (uint8) // TODO: need to set the size of map
+        {
+            case 0xc1: list<protocol::codec::AmqpKeyValue> map8;
+            case 0xd1: list<protocol::codec::AmqpKeyValue> map32;
+        }
+
+        struct AmqpKeyValue
+        {
+            protocol::codec::AmqpSymbol key;
+            protocol::codec::AmqpSymbol value;
+        }
+
+        struct AmqpProperty
+        {
+            protocol::codec::AmqpSymbol key;
+            protocol::codec::AmqpSymbol value; // TODO: not sure about the type
+        }
+
+        // 2.8 Definitions
+        enum AmqpRole
+        {
+            SENDER,
+            RECEIVER
+        }
+
+        enum AmqpSenderSettleMode
+        {
+            UNSETTLED,
+            SETTLED,
+            MIZED
+        }
+
+        enum AmqpReceiverSettleMode
+        {
+            FIRST,
+            SECOND
+        }
+
+        struct Error
+        {
+            protocol::codec::AmqpError condition;
+            protocol::codec::AmqpString description;
+            protocol::codec::AmqpMap info;
+        }
+
+        enum AmqpError // TODO: need to store values associated with names
+        {
+             INTERNAL_ERROR,
+             NOT_FOUND,
+             UNAUTHORIZED_ACCESS,
+             DECODE_ERROR,
+             RESOURCE_LIMIT_EXCEEDED,
+             NOT_ALLOWED,
+             INVALID_FIELD,
+             NOT_IMPLEMENTED,
+             RESOURCE_LOCKED,
+             PRECONDITION_FAILED,
+             RESOURCE_DELETED,
+             ILLEGAL_STATE,
+             FRAME_SIZE_TOO_SMALL
+        }
+
+        // 3.4 Delivery state
+        union AmqpDeliveryState switch (uint8)
+        {
+            case 0x23: protocol::codec::AmqpReceived received;
+            case 0x25: protocol::codec::AmqpRejected rejected;
+            case 0x26: protocol::codec::AmqpReleased released;
+            case 0x27: protocol::codec::AmqpModified modified;
+            case 0x33: protocol::codec::AmqpDeclared declared;
+            case 0x34: protocol::codec::AmqpTransactionalState transactionalState;
+        }
+
+        union AmqpOutcome switch (uint8)
+        {
+            case 0x24: protocol::codec::AmqpAccepted accepted;
+            case 0x25: protocol::codec::AmqpRejected rejected;
+            case 0x26: protocol::codec::AmqpReleased released;
+            case 0x27: protocol::codec::AmqpModified modified;
+            case 0x33: protocol::codec::AmqpDeclared declared;
+        }
+
+        struct AmqpReceived
+        {
+            protocol::codec::AmqpUInt sectionNumber; // required
+            protocol::codec::AmqpULong sectionOffset; // required
+        }
+
+        struct AmqpAccepted
+        {
+            // TODO
+        }
+
+        struct AmqpRejected
+        {
+            protocol::codec::Error error;
+        }
+
+        struct AmqpReleased
+        {
+            // TODO
+        }
+
+        struct AmqpModified
+        {
+            protocol::codec::AmqpBoolean deliveryFailed;
+            protocol::codec::AmqpBoolean undeliverableHere;
+            protocol::codec::AmqpMap messageAnnotations;
+        }
+
+        struct AmqpTransactionalState
+        {
+            protocol::codec::AmqpBinary txnId; // required
+            protocol::codec::AmqpOutcome outcome;
+        }
+
+        // 3.5 Sources and Targets
+        enum AmqpDistributionMode
+        {
+            MOVE,
+            COPY
+        }
+
+        struct AmqpSource
+        {
+            protocol::codec::AmqpString address;
+            protocol::codec::AmqpTerminusDurability durable;
+            protocol::codec::AmqpTerminusExpiryPolicy expiryPolicy;
+            protocol::codec::AmqpUInt timeout;
+            protocol::codec::AmqpBoolean dynamic;
+            protocol::codec::AmqpMap dynamicNodeProperties;
+            protocol::codec::AmqpDistributionMode distributionMode;
+            protocol::codec::AmqpMap filter;
+            protocol::codec::AmqpOutcome defaultOutcome;
+            list<protocol::codec::AmqpSymbol> outcomes;
+            list<protocol::codec::AmqpSymbol> capabilities;
+        }
+
+        struct AmqpTarget
+        {
+            protocol::codec::AmqpString address;
+            protocol::codec::AmqpTerminusDurability durable;
+            protocol::codec::AmqpTerminusExpiryPolicy expiryPolicy;
+            protocol::codec::AmqpUInt timeout;
+            protocol::codec::AmqpBoolean dynamic;
+            protocol::codec::AmqpMap dynamicNodeProperties;
+            list<protocol::codec::AmqpSymbol> capabilities;
+        }
+
+        enum AmqpTerminusDurability
+        {
+            NONE,
+            CONFIGURATION,
+            UNSETTLED_STATE
+        }
+
+        enum AmqpTerminusExpiryPolicy
+        {
+            LINK_DETACH,
+            SESSION_END,
+            CONNECTION_CLOSE,
+            NEVER
+        }
+
+        enum StandardDistributionMode
+        {
+            MOVE,
+            COPY
+        }
+
+        // 2.7 Performatives
+        struct AmqpOpenFrame // TODO: struct requires all the properties --> need optional fields
+        {
+            protocol::codec::AmqpString containerId; // required
+            protocol::codec::AmqpString hostname;
+            protocol::codec::AmqpUInt maxFrameSize;
+            uint16 channelMax;
+            protocol::codec::AmqpUInt idleTimeOut;
+            list<protocol::codec::AmqpSymbol> outgoingLocales;
+            list<protocol::codec::AmqpSymbol> incomingLocales;
+            list<protocol::codec::AmqpSymbol> offeredCapabilities;
+            list<protocol::codec::AmqpSymbol> desiredCapabilities;
+            list<protocol::codec::AmqpProperty> properties;
+        }
+
+        struct AmqpBeginFrame
+        {
+            uint16 remoteChannel;
+            uint32 nextOutgoingId; // required
+            protocol::codec::AmqpUInt incomingWindow; // required
+            protocol::codec::AmqpUInt outgoingWindow; // required
+            protocol::codec::AmqpUInt handleMax;
+            list<protocol::codec::AmqpSymbol> offeredCapabilities;
+            list<protocol::codec::AmqpSymbol> desiredCapabilities;
+            list<protocol::codec::AmqpProperty> properties;
+        }
+
+        struct AmqpAttachFrame
+        {
+            protocol::codec::AmqpString name; // required
+            protocol::codec::AmqpUInt handle; // required
+            protocol::codec::AmqpRole role; // required
+            protocol::codec::AmqpSenderSettleMode sndSettleMode;
+            protocol::codec::AmqpReceiverSettleMode rcvSettleMode;
+            protocol::codec::AmqpSource source;
+            protocol::codec::AmqpTarget target;
+            protocol::codec::AmqpMap unsettled;
+            protocol::codec::AmqpBoolean incompleteUnsettled;
+            protocol::codec::AmqpUInt initialDeliveryCount;
+            protocol::codec::AmqpULong maxMessageSize;
+            list<protocol::codec::AmqpSymbol> offeredCapabilities;
+            list<protocol::codec::AmqpSymbol> desiredCapabilities;
+            list<protocol::codec::AmqpProperty> properties;
+        }
+
+        struct AmqpFlowFrame
+        {
+            protocol::codec::AmqpUInt nextIncomingId;
+            protocol::codec::AmqpUInt incomingWindow; // required
+            protocol::codec::AmqpUInt nextOutgoingId; // required
+            protocol::codec::AmqpUInt outgoingWindow;  // required
+            protocol::codec::AmqpUInt handle;
+            protocol::codec::AmqpUInt deliveryCount;
+            protocol::codec::AmqpUInt linkCredit;
+            protocol::codec::AmqpUInt available;
+            protocol::codec::AmqpBoolean drain;
+            protocol::codec::AmqpBoolean echo;
+            list<protocol::codec::AmqpProperty> properties;
+        }
+
+        struct AmqpTransferFrame
+        {
+            protocol::codec::AmqpUInt handle; // required
+            protocol::codec::AmqpUInt deliveryId;
+            protocol::codec::AmqpBinary deliveryTag;
+            protocol::codec::AmqpMessageFormat messageFormat;
+            protocol::codec::AmqpBoolean settled;
+            protocol::codec::AmqpBoolean more;
+            protocol::codec::AmqpReceiverSettleMode rcvSettleMode;
+            protocol::codec::AmqpDeliveryState state;
+            protocol::codec::AmqpBoolean resume;
+            protocol::codec::AmqpBoolean aborted;
+            protocol::codec::AmqpBoolean batchable;
+        }
+
+        struct AmqpDispositionFrame
+        {
+            protocol::codec::AmqpRole role; // required
+            protocol::codec::AmqpUInt first; // required
+            protocol::codec::AmqpUInt last;
+            protocol::codec::AmqpBoolean settled;
+            protocol::codec::AmqpDeliveryState state;
+            protocol::codec::AmqpBoolean batchable;
+        }
+
+        struct AmqpDetachFrame
+        {
+            protocol::codec::AmqpUInt handle; // required
+            protocol::codec::AmqpBoolean closed;
+            protocol::codec::Error error;
+        }
+
+        struct AmqpEndFrame
+        {
+            protocol::codec::Error error;
+        }
+
+        struct AmqpCloseFrame
+        {
+            protocol::codec::Error error;
+        }
+
+        struct AmqpMessageFormat
+        {
+            octets[3] messageFormat;
+            octets[1] version;
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.reaktivity.nukleus.ControllerFactorySpi
+++ b/src/main/resources/META-INF/services/org.reaktivity.nukleus.ControllerFactorySpi
@@ -1,0 +1,1 @@
+org.reaktivity.nukleus.amqp.internal.AmqpControllerFactorySpi

--- a/src/main/resources/META-INF/services/org.reaktivity.nukleus.NukleusFactorySpi
+++ b/src/main/resources/META-INF/services/org.reaktivity.nukleus.NukleusFactorySpi
@@ -1,0 +1,1 @@
+org.reaktivity.nukleus.amqp.internal.AmqpNukleusFactorySpi

--- a/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
@@ -17,6 +17,7 @@ package org.reaktivity.nukleus.amqp.internal.streams.server;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
+import static org.reaktivity.nukleus.amqp.internal.AmqpConfiguration.AMQP_CONTAINER_ID;
 import static org.reaktivity.reaktor.test.ReaktorRule.EXTERNAL_AFFINITY_MASK;
 
 import org.junit.Ignore;
@@ -45,6 +46,7 @@ public class AmqpServerIT
         .counterValuesBufferCapacity(8192)
         .nukleus("amqp"::equals)
         .affinityMask("target#0", EXTERNAL_AFFINITY_MASK)
+        .configure(AMQP_CONTAINER_ID.name(), "localhost")
         .clean();
 
     @Rule

--- a/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
@@ -33,7 +33,7 @@ public class AmqpServerIT
 {
     private final K3poRule k3po = new K3poRule()
         .addScriptRoot("route", "org/reaktivity/specification/nukleus/amqp/control/route")
-        .addScriptRoot("client", "org/reaktivity/specification/amqp/link")
+        .addScriptRoot("client", "org/reaktivity/specification/amqp")
         .addScriptRoot("server", "org/reaktivity/specification/nukleus/amqp/streams");
 
     private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
@@ -50,11 +50,21 @@ public class AmqpServerIT
     @Rule
     public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
 
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/connection/header.exchange/handshake.client" })
+    public void shouldExchangeHeader() throws Exception
+    {
+        k3po.finish();
+    }
+
     @Ignore
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/attach.as.receiver.only/client",
+        "${client}/link/attach.as.receiver.only/client",
         "${server}/connect.as.receiver.only/server" })
     public void shouldConnectAsReceiverOnly() throws Exception
     {
@@ -65,7 +75,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/attach.as.receiver.then.sender/client",
+        "${client}/link/attach.as.receiver.then.sender/client",
         "${server}/connect.as.receiver.then.sender/server" })
     public void shouldConnectAsReceiverThenSender() throws Exception
     {
@@ -76,7 +86,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/attach.as.sender.only/client",
+        "${client}/link/attach.as.sender.only/client",
         "${server}/connect.as.sender.only/server" })
     public void shouldConnectAsSenderOnly() throws Exception
     {
@@ -87,7 +97,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/attach.as.sender.then.receiver/client",
+        "${client}/link/attach.as.sender.then.receiver/client",
         "${server}/connect.as.sender.then.receiver/server" })
     public void shouldConnectAsSenderThenReceiver() throws Exception
     {
@@ -98,7 +108,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/detach.link/client",
+        "${client}/link/detach.link/client",
         "${server}/disconnect.abort/server" })
     public void shouldDisconnectWithAbort() throws Exception
     {
@@ -109,7 +119,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/transfer.to.client.at.least.once/client",
+        "${client}/link/transfer.to.client.at.least.once/client",
         "${server}/send.to.client.at.least.once/server" })
     public void shouldSendToClientAtLeastOnce() throws Exception
     {
@@ -120,7 +130,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/transfer.to.client.at.most.once/client",
+        "${client}/link/transfer.to.client.at.most.once/client",
         "${server}/send.to.client.at.most.once/server" })
     public void shouldSendToClientAtMostOnce() throws Exception
     {
@@ -131,7 +141,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/transfer.to.server.at.least.once/client",
+        "${client}/link/transfer.to.server.at.least.once/client",
         "${server}/send.to.server.at.least.once/server" })
     public void shouldSendToServerAtLeastOnce() throws Exception
     {
@@ -142,7 +152,7 @@ public class AmqpServerIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/transfer.to.server.at.most.once/client",
+        "${client}/link/transfer.to.server.at.most.once/client",
         "${server}/send.to.server.at.most.once/server" })
     public void shouldSendToServerAtMostOnce() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/amqp/internal/streams/server/AmqpServerIT.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.amqp.internal.streams.server;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.rules.RuleChain.outerRule;
+import static org.reaktivity.reaktor.test.ReaktorRule.EXTERNAL_AFFINITY_MASK;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.reaktivity.reaktor.test.ReaktorRule;
+
+public class AmqpServerIT
+{
+    private final K3poRule k3po = new K3poRule()
+        .addScriptRoot("route", "org/reaktivity/specification/nukleus/amqp/control/route")
+        .addScriptRoot("client", "org/reaktivity/specification/amqp/link")
+        .addScriptRoot("server", "org/reaktivity/specification/nukleus/amqp/streams");
+
+    private final TestRule timeout = new DisableOnDebug(new Timeout(10, SECONDS));
+
+    private final ReaktorRule reaktor = new ReaktorRule()
+        .directory("target/nukleus-itests")
+        .commandBufferCapacity(1024)
+        .responseBufferCapacity(1024)
+        .counterValuesBufferCapacity(8192)
+        .nukleus("amqp"::equals)
+        .affinityMask("target#0", EXTERNAL_AFFINITY_MASK)
+        .clean();
+
+    @Rule
+    public final TestRule chain = outerRule(reaktor).around(k3po).around(timeout);
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/attach.as.receiver.only/client",
+        "${server}/connect.as.receiver.only/server" })
+    public void shouldConnectAsReceiverOnly() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/attach.as.receiver.then.sender/client",
+        "${server}/connect.as.receiver.then.sender/server" })
+    public void shouldConnectAsReceiverThenSender() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/attach.as.sender.only/client",
+        "${server}/connect.as.sender.only/server" })
+    public void shouldConnectAsSenderOnly() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/attach.as.sender.then.receiver/client",
+        "${server}/connect.as.sender.then.receiver/server" })
+    public void shouldConnectAsSenderThenReceiver() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/detach.link/client",
+        "${server}/disconnect.abort/server" })
+    public void shouldDisconnectWithAbort() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/transfer.to.client.at.least.once/client",
+        "${server}/send.to.client.at.least.once/server" })
+    public void shouldSendToClientAtLeastOnce() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/transfer.to.client.at.most.once/client",
+        "${server}/send.to.client.at.most.once/server" })
+    public void shouldSendToClientAtMostOnce() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/transfer.to.server.at.least.once/client",
+        "${server}/send.to.server.at.least.once/server" })
+    public void shouldSendToServerAtLeastOnce() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Ignore
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/transfer.to.server.at.most.once/client",
+        "${server}/send.to.server.at.most.once/server" })
+    public void shouldSendToServerAtMostOnce() throws Exception
+    {
+        k3po.finish();
+    }
+}


### PR DESCRIPTION
### Major changes
- Created the following classes
    - `AmqpConfiguration`
    - `AmqpController`
    - `AmqpControllerFactorySpi`
    - `AmqpElektron`
    - `AmqpNukleus`
    - `AmqpNukleusFactorySpi`
    - `AmqpClientFactoryBuilder` (Not implemented yet)
    - `AmqpServerFactory`
    - `AmqpServerFactoryBuilder`
    - `AmqpFrameFW`
    - `AmqpHeaderFW` (Not implemented yet)

- `AmqpServerFactory`
	- Implemented methods that the header exchange test case requires to pass
