### PR TITLE
Update pom.xml to allow empty deliveryTag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 
     <k3po.version>3.0.0</k3po.version>
 
-    <nukleus.plugin.version>0.68</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
 
-    <nukleus.amqp.spec.version>0.30</nukleus.amqp.spec.version>
+    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
     <reaktor.version>0.140</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.70</nukleus.plugin.version>
 
-    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
+    <nukleus.amqp.spec.version>0.32</nukleus.amqp.spec.version>
     <reaktor.version>0.140</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <k3po.version>3.0.0</k3po.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.70</nukleus.plugin.version>
 
     <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
     <reaktor.version>0.140</reaktor.version>


### PR DESCRIPTION
Fix #51.
Requires https://github.com/reaktivity/nukleus-amqp.spec/pull/27 and https://github.com/reaktivity/nukleus-maven-plugin/pull/129.