### PR TITLE
Fix delivery-id assignment after message aborted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.74</nukleus.plugin.version>
 
-    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
+    <nukleus.amqp.spec.version>0.56</nukleus.amqp.spec.version>
     <reaktor.version>0.152</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.74</nukleus.plugin.version>
 
-    <nukleus.amqp.spec.version>0.55</nukleus.amqp.spec.version>
+    <nukleus.amqp.spec.version>develop-SNAPSHOT</nukleus.amqp.spec.version>
     <reaktor.version>0.152</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/amqp/internal/stream/AmqpServerFactory.java
@@ -1149,13 +1149,15 @@ public final class AmqpServerFactory implements StreamFactory
                 if (!sender.fragmented)
                 {
                     assert deliveryId != NO_DELIVERY_ID; // TODO: error
+                    session.remoteDeliveryId = sequenceNext(session.remoteDeliveryId);
+
                     if (transfer.hasAborted() && transfer.aborted() == 1)
                     {
                         progress = limit;
                         server.decoder = decodePlainFrame;
                         break decode;
                     }
-                    session.remoteDeliveryId = sequenceNext(session.remoteDeliveryId);
+
                     if (deliveryId != session.remoteDeliveryId)
                     {
                         server.onDecodeError(traceId, authorization, INVALID_FIELD, null);


### PR DESCRIPTION
Fix #63 
Requires https://github.com/reaktivity/nukleus-amqp.spec/pull/54